### PR TITLE
Ajout du capteur de la dernière conso dispo

### DIFF
--- a/custom_components/octopus_french/coordinator.py
+++ b/custom_components/octopus_french/coordinator.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-
 class OctopusFrenchDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
@@ -92,6 +91,7 @@ class OctopusFrenchDataUpdateCoordinator(DataUpdateCoordinator):
         # Récupération des données électricité (journalières agrégées)
         electricity_readings = []
         elec_index = None
+        latest_electricity_reading = None
 
         if electricity_meter_id:
             electricity_readings = await self.api_client.get_energy_readings(
@@ -109,10 +109,18 @@ class OctopusFrenchDataUpdateCoordinator(DataUpdateCoordinator):
                 account_number, electricity_meter_id
             )
 
+            latest_electricity_reading = await self.api_client.get_latest_energy_reading(
+                property_id=account_id,
+                market_supply_point_id=electricity_meter_id,
+                utility_type="electricity",
+                reading_frequency="DAY_INTERVAL",
+            )
+
         # Stocker les données électricité
         account_data["electricity"] = {
             "readings": electricity_readings,
             "index": elec_index,
+            "latest_reading": latest_electricity_reading,
         }
 
         # Récupération des données gaz (mensuelles)

--- a/custom_components/octopus_french/strings.json
+++ b/custom_components/octopus_french/strings.json
@@ -114,6 +114,17 @@
           }
         }
       },
+      "dernier_releve": {
+        "name": "Dernier releve",
+        "state_attributes": {
+          "start_at": {
+            "name": "Date du releve"
+          },
+          "meta": {
+            "name": "Metadonnees"
+          }
+        }
+      },
       "index_base": {
         "name": "Meter index",
         "state_attributes": {

--- a/custom_components/octopus_french/translations/en.json
+++ b/custom_components/octopus_french/translations/en.json
@@ -114,6 +114,17 @@
           }
         }
       },
+      "dernier_releve": {
+        "name": "Latest reading",
+        "state_attributes": {
+          "start_at": {
+            "name": "Reading date"
+          },
+          "meta": {
+            "name": "Metadata"
+          }
+        }
+      },
       "index_base": {
         "name": "Meter index",
         "state_attributes": {

--- a/custom_components/octopus_french/translations/fr.json
+++ b/custom_components/octopus_french/translations/fr.json
@@ -114,6 +114,17 @@
           }
         }
       },
+      "dernier_releve": {
+        "name": "Dernier relevé",
+        "state_attributes": {
+          "start_at": {
+            "name": "Date du relevé"
+          },
+          "meta": {
+            "name": "Métadonnées"
+          }
+        }
+      },
       "index_base": {
         "name": "Index",
         "state_attributes": {


### PR DESCRIPTION
Résumé
Ajout du capteur dernier_releve (dernier relevé journalier) dans l’intégration, avec récupération côté API et exposition dans Home Assistant.

Changements
Ajout de la récupération du dernier relevé via l’API.
Stockage dans le coordinator (latest_reading).
Nouveau capteur HA dernier_releve.
Ajout des traductions FR/EN.
