### PR TITLE
fix: SyntaxError bloquante, NoneType imbriqué et robustesse auth (issue #51)

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -35,10 +35,25 @@ jobs:
           category: integration
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  syntax:
+    name: Python syntax check
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v7
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: 🧪 Compile all sources
+        run: python -m compileall -q custom_components/octopus_french
+
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [validate, hacs]
+    needs: [validate, hacs, syntax]
     permissions:
       contents: write
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## [3.3.4] - 2026-07-13
+
+Correctifs critiques révélés par le diagnostic des logs de l'issue #51 (« Invalid credentials & no attribute 'get' »).
+
+### 🔴 Correction bloquante — `SyntaxError` empêchant le chargement du module
+
+Le paquet utilisait la syntaxe d'exception Python 2 `except A, B:` (invalide en Python 3), présente depuis la 3.3.0 dans **3 fichiers** : `octopus_french.py`, `sensors/electricity.py` (4 occurrences) et `sensors/gas.py`. Sous le Python de Home Assistant, ces modules **ne compilaient pas** et l'intégration ne pouvait pas se charger.
+
+- Toutes les clauses corrigées en `except (A, B):`.
+- Ajout d'un job CI `Python syntax check` (`compileall` sous Python 3.13), en dépendance du job de release, pour bloquer toute release en cas d'erreur de syntaxe (hassfest ne compile pas les sources).
+
+### 🐛 Correction — `'NoneType' object has no attribute 'get'` sur réponses partielles
+
+Le correctif 3.3.3+ ne sécurisait que le `data` de premier niveau. Les accès imbriqués `X.get("clé", {}).get(...)` re-crashaient quand l'API renvoyait un sous-objet explicitement `null` (le défaut `{}` ne protège que si la clé est **absente**, pas si elle vaut `null`) : `supplyPoints`, `agreements`, `creditStorage`, `supplyPoint`, `product`, `consumptionRates`, `measurements`, `gasReading`, `paymentRequest`, `node`, `meterPoint`.
+
+- Remplacement systématique par `(X.get("clé") or {}).get(...)` dans `octopus_french.py` (extracteurs `_extract_ledgers`, `_extract_supply_points`, `_extract_agreements`, `_extract_tariffs` et méthodes de lecture élec/gaz/paiements).
+
+### 🔐 Robustesse authentification — refresh token & rate-limit Kraken
+
+Les logs montraient une boucle `Unauthorized` → re-login complet → `Too many requests` : chaque erreur déclenchait un login email/mot de passe, ce qui trippe le rate-limit dynamique de Kraken (code `KT-CT-1199`, plafond dégressif jusqu'à ~1 req/h). La [doc API](https://developer.octopus.energy/guides/graphql/api-basics/) recommande de rafraîchir le token via un `refreshToken`.
+
+- Le login demande désormais `token`, `refreshToken` et `refreshExpiresIn` ; le `token` (60 min) est rafraîchi via le `refreshToken` (7 j) **sans re-login complet**, le login email/mot de passe n'étant refait que si le refresh échoue ou expire (`TokenManager`, `authenticate()`).
+- `clear()` ne purge que le token d'accès (refresh réutilisable), `clear_all()` purge tout.
+- Détection du rate-limit `KT-CT-1199` → nouvelle exception `OctopusRateLimitError` (sous-classe d'`OctopusConnectionError`), mappée en `ConfigEntryNotReady` (retry temporisé) au lieu du trompeur `ConfigEntryAuthFailed` « invalid credentials ».
+
+---
+
 ## [3.3.3] - 2026-07-09
 
 Cette version est une **mise en conformité aux standards Home Assistant** accompagnée de deux corrections côté utilisateur (comptes multiples et capteur de contrat).

--- a/custom_components/octopus_french/__init__.py
+++ b/custom_components/octopus_french/__init__.py
@@ -110,7 +110,14 @@ async def async_setup_entry(
 
 
 async def _async_authenticate(api_client: OctopusFrenchApiClient) -> None:
-    if not await api_client.authenticate():
+    try:
+        authenticated = await api_client.authenticate()
+    except OctopusConnectionError as err:
+        # Includes rate limiting (KT-CT-1199): temporary, let HA back off and retry
+        # instead of forcing a re-auth prompt.
+        raise ConfigEntryNotReady(f"Cannot connect to Octopus API: {err}") from err
+
+    if not authenticated:
         raise ConfigEntryAuthFailed("Authentication failed - invalid credentials")
 
 

--- a/custom_components/octopus_french/manifest.json
+++ b/custom_components/octopus_french/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/domodom30/ha-octopus-french/issues",
   "requirements": ["PyJWT==2.12.1"],
-  "version": "3.3.3"
+  "version": "3.3.4"
 }

--- a/custom_components/octopus_french/octopus_french.py
+++ b/custom_components/octopus_french/octopus_french.py
@@ -21,16 +21,23 @@ class OctopusConnectionError(Exception):
     """Raised when the API cannot be reached (network or server error)."""
 
 
+class OctopusRateLimitError(OctopusConnectionError):
+    """Raised when the API rate limit (KT-CT-1199) is hit; the caller should retry later."""
+
+
 GRAPHQL_ENDPOINT = "https://api.oefr-kraken.energy/v1/graphql/"
 
 TOKEN_EXPIRY_BUFFER = 60
 MAX_RETRY_ATTEMPTS = 3
 RETRY_DELAY = 1
+RATE_LIMIT_ERROR_CODE = "KT-CT-1199"
 
 MUTATION_LOGIN = """
 mutation obtainKrakenToken($input: ObtainJSONWebTokenInput!) {
     obtainKrakenToken(input: $input) {
         token
+        refreshToken
+        refreshExpiresIn
     }
 }
 """
@@ -308,11 +315,18 @@ class TokenManager:
         """Initialize the token manager."""
         self._token: str | None = None
         self._expiry: float | None = None
+        self._refresh_token: str | None = None
+        self._refresh_expiry: float | None = None
 
     @property
     def token(self) -> str | None:
         """Get the current token."""
         return self._token
+
+    @property
+    def refresh_token(self) -> str | None:
+        """Get the current refresh token."""
+        return self._refresh_token
 
     @property
     def is_valid(self) -> bool:
@@ -325,27 +339,58 @@ class TokenManager:
         return now < (self._expiry - TOKEN_EXPIRY_BUFFER)
 
     @property
+    def is_refresh_valid(self) -> bool:
+        """Check if the refresh token can still be used."""
+        if not self._refresh_token:
+            return False
+        if self._refresh_expiry is None:
+            return True
+
+        now = datetime.now(UTC).timestamp()
+
+        return now < (self._refresh_expiry - TOKEN_EXPIRY_BUFFER)
+
+    @property
     def expires_in(self) -> float:
         """Get seconds until token expiry."""
         if not self._expiry:
             return 0
         return max(0, self._expiry - datetime.now(UTC).timestamp())
 
-    def set_token(self, token: str) -> None:
-        """Set a new token and decode its expiry."""
+    def set_token(
+        self,
+        token: str,
+        refresh_token: str | None = None,
+        refresh_expires_in: float | None = None,
+    ) -> None:
+        """Set a new token (and optional refresh token) and decode expiries."""
         self._token = token
 
+        self._expiry = datetime.now(UTC).timestamp() + 3600
         with suppress(Exception):
             decoded = jwt.decode(token, options={"verify_signature": False})
             if exp := decoded.get("exp"):
                 self._expiry = float(exp)
-                return
-        self._expiry = datetime.now(UTC).timestamp() + 3600
+
+        if refresh_token:
+            self._refresh_token = refresh_token
+            self._refresh_expiry = (
+                datetime.now(UTC).timestamp() + float(refresh_expires_in)
+                if refresh_expires_in
+                else None
+            )
 
     def clear(self) -> None:
-        """Clear token and expiry."""
+        """Clear the access token (keeps the refresh token for reuse)."""
         self._token = None
         self._expiry = None
+
+    def clear_all(self) -> None:
+        """Clear both the access token and the refresh token."""
+        self._token = None
+        self._expiry = None
+        self._refresh_token = None
+        self._refresh_expiry = None
 
 
 class OctopusFrenchApiClient:
@@ -396,7 +441,7 @@ class OctopusFrenchApiClient:
                     )
                     if attempt < MAX_RETRY_ATTEMPTS - 1:
                         await asyncio.sleep(RETRY_DELAY * (attempt + 1))
-            except aiohttp.ClientError, TimeoutError:
+            except (aiohttp.ClientError, TimeoutError):
                 if attempt < MAX_RETRY_ATTEMPTS - 1:
                     await asyncio.sleep(RETRY_DELAY * (attempt + 1))
                     continue
@@ -412,42 +457,94 @@ class OctopusFrenchApiClient:
             for error in result.get("errors", [])
         ]
 
+    @staticmethod
+    def _is_rate_limited(result: dict[str, Any]) -> bool:
+        """Return True if the response signals the KT-CT-1199 rate limit."""
+        for error in result.get("errors", []):
+            extensions = error.get("extensions") or {}
+            if extensions.get("errorCode") == RATE_LIMIT_ERROR_CODE:
+                return True
+            if "too many requests" in (error.get("message") or "").lower():
+                return True
+        return False
+
+    async def _obtain_token(self, variables: dict[str, Any]) -> dict[str, Any]:
+        """Run the obtainKrakenToken mutation, surfacing rate limits explicitly."""
+        result = await self._async_execute(query=MUTATION_LOGIN, variables=variables)
+
+        if not result:
+            raise OctopusConnectionError("Failed to reach authentication server")
+
+        if self._is_rate_limited(result):
+            raise OctopusRateLimitError(
+                f"Rate limited by API ({RATE_LIMIT_ERROR_CODE}): "
+                + ", ".join(self._extract_error_messages(result))
+            )
+
+        return result
+
+    def _store_tokens(self, result: dict[str, Any]) -> bool:
+        """Persist token/refreshToken from a login response; return success."""
+        payload = (result.get("data") or {}).get("obtainKrakenToken") or {}
+        token = payload.get("token")
+        if not token:
+            return False
+
+        self.token_manager.set_token(
+            token,
+            refresh_token=payload.get("refreshToken"),
+            refresh_expires_in=payload.get("refreshExpiresIn"),
+        )
+        return True
+
+    async def _refresh_access_token(self) -> bool:
+        """Obtain a fresh access token via the refresh token (no full re-login)."""
+        try:
+            result = await self._obtain_token(
+                {"input": {"refreshToken": self.token_manager.refresh_token}}
+            )
+        except OctopusRateLimitError:
+            raise
+        except OctopusConnectionError:
+            return False
+
+        if self._store_tokens(result):
+            return True
+
+        _LOGGER.debug("Refresh token rejected, falling back to a full login")
+        self.token_manager.clear_all()
+        return False
+
+    async def _login_with_credentials(self) -> bool:
+        """Authenticate with email/password (full login)."""
+        result = await self._obtain_token(
+            {"input": {"email": self.email, "password": self.password}}
+        )
+
+        if self._store_tokens(result):
+            return True
+
+        error_messages = self._extract_error_messages(result) or ["Invalid credentials"]
+        _LOGGER.warning("Authentication failed: %s", ", ".join(error_messages))
+        return False
+
     async def authenticate(self) -> bool:
-        """Authenticate with the API (thread-safe)."""
+        """Authenticate with the API (thread-safe).
+
+        Prefers refreshing via the cached refresh token to avoid repeated full
+        logins, which quickly trip the Kraken dynamic rate limit (KT-CT-1199).
+        """
         async with self._auth_lock:
             if self.token_manager.is_valid:
                 return True
 
-            variables = {
-                "input": {
-                    "email": self.email,
-                    "password": self.password,
-                }
-            }
+            if (
+                self.token_manager.is_refresh_valid
+                and await self._refresh_access_token()
+            ):
+                return True
 
-            result = await self._async_execute(
-                query=MUTATION_LOGIN,
-                variables=variables,
-            )
-
-            if not result:
-                raise OctopusConnectionError("Failed to reach authentication server")
-
-            token = ((result.get("data") or {}).get("obtainKrakenToken") or {}).get(
-                "token"
-            )
-
-            if not token:
-                error_messages = self._extract_error_messages(result) or [
-                    "Invalid credentials"
-                ]
-                _LOGGER.warning(
-                    "Authentication failed: %s", ", ".join(error_messages)
-                )
-                return False
-
-            self.token_manager.set_token(token)
-            return True
+            return await self._login_with_credentials()
 
     async def execute_with_auth(
         self,
@@ -470,6 +567,12 @@ class OctopusFrenchApiClient:
 
         if "errors" in result:
             error_messages = self._extract_error_messages(result)
+
+            if self._is_rate_limited(result):
+                raise OctopusRateLimitError(
+                    f"Rate limited by API ({RATE_LIMIT_ERROR_CODE}): "
+                    + "; ".join(error_messages)
+                )
 
             auth_keywords = {"authentication", "unauthorized", "token", "expired"}
             is_auth_error = any(
@@ -539,10 +642,10 @@ class OctopusFrenchApiClient:
             if not isinstance(prop, dict):
                 continue
 
-            edges = prop.get("supplyPoints", {}).get("edges", [])
+            edges = (prop.get("supplyPoints") or {}).get("edges", [])
             for edge in edges:
-                node = edge.get("node", {})
-                meter_point = node.get("meterPoint", {})
+                node = edge.get("node") or {}
+                meter_point = node.get("meterPoint") or {}
 
                 if meter_point.get("distributorStatus") == "RESIL":
                     continue
@@ -582,7 +685,7 @@ class OctopusFrenchApiClient:
                     "number": ledger.get("number", ""),
                 }
 
-        ledger_data = account.get("creditStorage", {}).get("ledger", [])
+        ledger_data = (account.get("creditStorage") or {}).get("ledger", [])
         if not isinstance(ledger_data, list):
             ledger_data = [ledger_data]
 
@@ -610,10 +713,10 @@ class OctopusFrenchApiClient:
             if not isinstance(prop, dict):
                 continue
 
-            edges = prop.get("supplyPoints", {}).get("edges", [])
+            edges = (prop.get("supplyPoints") or {}).get("edges", [])
             for edge in edges:
-                node = edge.get("node", {})
-                meter_point = node.get("meterPoint", {})
+                node = edge.get("node") or {}
+                meter_point = node.get("meterPoint") or {}
 
                 meter_point["prm"] = node.get("externalIdentifier")
                 meter_point["supply_point_id"] = node.get("id")
@@ -641,10 +744,10 @@ class OctopusFrenchApiClient:
         """Extract agreements with tariffs from account data."""
         agreements = []
 
-        agreement_edges = account.get("agreements", {}).get("edges", [])
+        agreement_edges = (account.get("agreements") or {}).get("edges", [])
 
         for edge in agreement_edges:
-            agreement = edge.get("node", {})
+            agreement = edge.get("node") or {}
 
             tariffs = None
             if energy_rate := agreement.get("energySupplyRate"):
@@ -656,12 +759,12 @@ class OctopusFrenchApiClient:
                 "valid_to": agreement.get("validTo"),
                 "is_active": agreement.get("isActive", False),
                 "contract_number": agreement.get("supplyContractNumber"),
-                "supply_point_id": agreement.get("supplyPoint", {}).get("id"),
-                "prm": agreement.get("supplyPoint", {}).get("externalIdentifier"),
+                "supply_point_id": (agreement.get("supplyPoint") or {}).get("id"),
+                "prm": (agreement.get("supplyPoint") or {}).get("externalIdentifier"),
                 "product": {
-                    "code": agreement.get("product", {}).get("code"),
-                    "name": agreement.get("product", {}).get("fullName"),
-                    "display_name": agreement.get("product", {}).get("displayName"),
+                    "code": (agreement.get("product") or {}).get("code"),
+                    "name": (agreement.get("product") or {}).get("fullName"),
+                    "display_name": (agreement.get("product") or {}).get("displayName"),
                 },
                 "tariffs": tariffs,
                 "billing_frequency_months": agreement.get("billingFrequency"),
@@ -736,8 +839,8 @@ class OctopusFrenchApiClient:
                 _LOGGER.warning("Error parsing standing rate: %s", e)
 
         consumption_rates = []
-        for rate_edge in energy_rate.get("consumptionRates", {}).get("edges", []):
-            rate = rate_edge.get("node", {})
+        for rate_edge in (energy_rate.get("consumptionRates") or {}).get("edges", []):
+            rate = rate_edge.get("node") or {}
             try:
                 temporal_class = rate.get("temporalClass") or {}
                 time_slots = rate.get("timeSlots") or []
@@ -851,8 +954,9 @@ class OctopusFrenchApiClient:
             result = await self.execute_with_auth(query=query, variables=variables)
             measurements = (
                 ((result.get("data") or {}).get("property") or {}).get(
-                    "measurements", {}
+                    "measurements"
                 )
+                or {}
             )
             all_nodes.extend(edge["node"] for edge in measurements.get("edges", []))
             page_info = measurements.get("pageInfo", {})
@@ -890,7 +994,7 @@ class OctopusFrenchApiClient:
             result = await self.execute_with_auth(
                 query=QUERY_GET_GAS_READINGS, variables=variables
             )
-            gas_reading = (result.get("data") or {}).get("gasReading", {})
+            gas_reading = (result.get("data") or {}).get("gasReading") or {}
 
             for edge in gas_reading.get("edges", []):
                 node = edge["node"]
@@ -922,8 +1026,9 @@ class OctopusFrenchApiClient:
 
         payment_requests = (
             ((result.get("data") or {}).get("paymentRequests") or {}).get(
-                "paymentRequest", {}
+                "paymentRequest"
             )
+            or {}
         )
 
         edges = payment_requests.get("edges", [])

--- a/custom_components/octopus_french/sensors/electricity.py
+++ b/custom_components/octopus_french/sensors/electricity.py
@@ -167,7 +167,7 @@ class OctopusElectricitySensor(CoordinatorEntity, SensorEntity):
                     ).astimezone(dt_util.DEFAULT_TIME_ZONE)
             else:
                 cumulative_sum = 0.0
-        except OSError, ValueError, TypeError:
+        except (OSError, ValueError, TypeError):
             _LOGGER.debug(
                 "Could not fetch last statistics for %s, starting sum at 0",
                 statistic_id,
@@ -291,7 +291,7 @@ class OctopusElectricitySensor(CoordinatorEntity, SensorEntity):
                 None,
                 {"sum"},
             )
-        except OSError, ValueError, TypeError:
+        except (OSError, ValueError, TypeError):
             _LOGGER.debug("Could not fetch anchor sum for %s, using 0", statistic_id)
             return 0.0
 
@@ -701,7 +701,7 @@ class OctopusElectricitySensor(CoordinatorEntity, SensorEntity):
         value = meter.get("subscribedMaxPower")
         try:
             return float(value) if value is not None else None
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             return None
 
     def _get_contract_type(self) -> str:
@@ -1073,7 +1073,7 @@ class OctopusTempoCurrentRateSensor(CoordinatorEntity, SensorEntity):
             start_min = int(sh) * 60 + int(sm)
             end_min = int(eh) * 60 + int(em)
             cur_min = current_time.hour * 60 + current_time.minute
-        except ValueError, IndexError:
+        except (ValueError, IndexError):
             return False
 
         if end_min <= start_min:

--- a/custom_components/octopus_french/sensors/gas.py
+++ b/custom_components/octopus_french/sensors/gas.py
@@ -147,7 +147,7 @@ class OctopusGasSensor(CoordinatorEntity, SensorEntity):
                     ).astimezone(dt_util.DEFAULT_TIME_ZONE)
             else:
                 cumulative_sum = 0.0
-        except OSError, ValueError, TypeError:
+        except (OSError, ValueError, TypeError):
             _LOGGER.debug(
                 "Could not fetch last statistics for %s, starting sum at 0",
                 statistic_id,


### PR DESCRIPTION
Corrige les problèmes remontés dans #51 (« Invalid credentials & no attribute 'get' »).
_(Remplace la PR #52, fermée involontairement suite à la suppression puis recréation de mon fork.)_

### 🔴 SyntaxError bloquante (depuis la 3.3.0)
La syntaxe Python 2 `except A, B:` était présente dans `octopus_french.py`,
`sensors/electricity.py` (×4) et `sensors/gas.py` → ces modules ne compilent pas
sous Python 3, l'intégration ne peut pas se charger. Corrigé en `except (A, B):`.
Ajout d'un job CI `Python syntax check` (compileall) qui bloque la release en cas
de récidive (hassfest ne compile pas les sources).

### 🐛 `'NoneType' object has no attribute 'get'` sur réponses partielles
Les accès imbriqués `X.get("k", {}).get(...)` re-crashaient quand un sous-objet
valait `null` (`supplyPoints`, `agreements`, `creditStorage`, `product`,
`measurements`, `gasReading`, `paymentRequest`…). Sécurisés en `(X.get("k") or {}).get(...)`.

### 🔐 Auth : refreshToken + rate-limit KT-CT-1199
Le re-login complet à chaque erreur déclenchait le rate-limit dynamique Kraken.
Passage au rafraîchissement via `refreshToken` (doc API), détection du
`KT-CT-1199` → `ConfigEntryNotReady` au lieu de « invalid credentials ».

Testé : intégration fonctionnelle après ces correctifs. `compileall` OK sous Python 3.13.