### PR TITLE
fix: repair broken import + add Smart Control suspend/restore switch

### DIFF
--- a/custom_components/octopus_french/api/intelligent.py
+++ b/custom_components/octopus_french/api/intelligent.py
@@ -1,5 +1,7 @@
 """API client for Octopus Intelligent features."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -23,6 +25,18 @@ mutation updateBoostCharge($deviceId: String!) {
 }
 """
 
+MUTATION_UPDATE_DEVICE_SMART_CONTROL = """
+mutation updateDeviceSmartControl($deviceId: ID!, $action: SmartControlAction!) {
+  updateDeviceSmartControl(input: { deviceId: $deviceId, action: $action }) {
+    id
+    name
+    status {
+      isSuspended
+    }
+  }
+}
+"""
+
 QUERY_DEVICES = """
 query devices($accountNumber: String!) {
   devices(accountNumber: $accountNumber) {
@@ -31,6 +45,7 @@ query devices($accountNumber: String!) {
     status {
       current
       currentState
+      isSuspended
     }
   }
 }
@@ -118,6 +133,24 @@ class OctopusIntelligentApiClient:
     ) -> tuple[dict[str, Any] | None, list[str]]:
         """Cancel boost charge. Returns (data, refusal_reasons)."""
         return await self._update_boost_charge(device_id, MUTATION_CANCEL_BOOST_CHARGE)
+
+    async def _update_smart_control(self, device_id: str, action: str) -> bool:
+        """Suspend or unsuspend Octopus's automatic smart control of a device."""
+        response = await self.api_client.execute_with_auth(
+            MUTATION_UPDATE_DEVICE_SMART_CONTROL,
+            {"deviceId": device_id, "action": action},
+        )
+        if response and "errors" in response:
+            return False
+        return response is not None and "data" in response
+
+    async def suspend_smart_control(self, device_id: str) -> bool:
+        """Suspend Octopus's automatic smart control (stops it interrupting charging)."""
+        return await self._update_smart_control(device_id, "SUSPEND")
+
+    async def unsuspend_smart_control(self, device_id: str) -> bool:
+        """Restore Octopus's automatic smart control."""
+        return await self._update_smart_control(device_id, "UNSUSPEND")
 
     async def get_devices(self, account_number: str) -> list[dict[str, Any]]:
         """Get list of Intelligent devices for an account."""

--- a/custom_components/octopus_french/api/intelligent.py
+++ b/custom_components/octopus_french/api/intelligent.py
@@ -74,7 +74,7 @@ query flexPlannedDispatches($deviceId: String!) {
 # Les 7 jours sont écrits en littéral : ce sont des enums GraphQL (pas des valeurs
 # interpolées). Seuls time/max varient et passent par des variables réutilisées.
 MUTATION_SET_DEVICE_PREFERENCES = """
-mutation setDevicePreferences($deviceId: String!, $time: String!, $max: Int!) {
+mutation setDevicePreferences($deviceId: ID!, $time: Time!, $max: Decimal!) {
   setDevicePreferences(input: {
     deviceId: $deviceId
     mode: CHARGE

--- a/custom_components/octopus_french/coordinator.py
+++ b/custom_components/octopus_french/coordinator.py
@@ -1,5 +1,7 @@
 """Data update coordinator for Octopus French Energy."""
 
+from __future__ import annotations
+
 import asyncio
 from datetime import timedelta
 import logging

--- a/custom_components/octopus_french/coordinator_intelligent.py
+++ b/custom_components/octopus_french/coordinator_intelligent.py
@@ -1,5 +1,7 @@
 """Data update coordinator for Octopus Intelligent features."""
 
+from __future__ import annotations
+
 from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, Any

--- a/custom_components/octopus_french/octopus_french.py
+++ b/custom_components/octopus_french/octopus_french.py
@@ -438,7 +438,7 @@ class OctopusFrenchApiClient:
                     )
                     if attempt < MAX_RETRY_ATTEMPTS - 1:
                         await asyncio.sleep(RETRY_DELAY * (attempt + 1))
-            except aiohttp.ClientError, TimeoutError:
+            except (aiohttp.ClientError, TimeoutError):
                 if attempt < MAX_RETRY_ATTEMPTS - 1:
                     await asyncio.sleep(RETRY_DELAY * (attempt + 1))
                     continue

--- a/custom_components/octopus_french/sensors/electricity.py
+++ b/custom_components/octopus_french/sensors/electricity.py
@@ -167,7 +167,7 @@ class OctopusElectricitySensor(CoordinatorEntity, SensorEntity):
                     ).astimezone(dt_util.DEFAULT_TIME_ZONE)
             else:
                 cumulative_sum = 0.0
-        except OSError, ValueError, TypeError:
+        except (OSError, ValueError, TypeError):
             _LOGGER.debug(
                 "Could not fetch last statistics for %s, starting sum at 0",
                 statistic_id,
@@ -291,7 +291,7 @@ class OctopusElectricitySensor(CoordinatorEntity, SensorEntity):
                 None,
                 {"sum"},
             )
-        except OSError, ValueError, TypeError:
+        except (OSError, ValueError, TypeError):
             _LOGGER.debug("Could not fetch anchor sum for %s, using 0", statistic_id)
             return 0.0
 
@@ -701,7 +701,7 @@ class OctopusElectricitySensor(CoordinatorEntity, SensorEntity):
         value = meter.get("subscribedMaxPower")
         try:
             return float(value) if value is not None else None
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             return None
 
     def _get_contract_type(self) -> str:
@@ -1073,7 +1073,7 @@ class OctopusTempoCurrentRateSensor(CoordinatorEntity, SensorEntity):
             start_min = int(sh) * 60 + int(sm)
             end_min = int(eh) * 60 + int(em)
             cur_min = current_time.hour * 60 + current_time.minute
-        except ValueError, IndexError:
+        except (ValueError, IndexError):
             return False
 
         if end_min <= start_min:

--- a/custom_components/octopus_french/sensors/gas.py
+++ b/custom_components/octopus_french/sensors/gas.py
@@ -147,7 +147,7 @@ class OctopusGasSensor(CoordinatorEntity, SensorEntity):
                     ).astimezone(dt_util.DEFAULT_TIME_ZONE)
             else:
                 cumulative_sum = 0.0
-        except OSError, ValueError, TypeError:
+        except (OSError, ValueError, TypeError):
             _LOGGER.debug(
                 "Could not fetch last statistics for %s, starting sum at 0",
                 statistic_id,

--- a/custom_components/octopus_french/strings.json
+++ b/custom_components/octopus_french/strings.json
@@ -777,6 +777,9 @@
             "name": "Refusal reasons"
           }
         }
+      },
+      "smart_control": {
+        "name": "Smart control"
       }
     },
     "number": {
@@ -808,6 +811,9 @@
     },
     "cancel_boost_charge_failed": {
       "message": "Failed to cancel boost charge: {reasons}."
+    },
+    "update_smart_control_failed": {
+      "message": "Failed to update smart control for device {device_id}."
     }
   }
 }

--- a/custom_components/octopus_french/switch.py
+++ b/custom_components/octopus_french/switch.py
@@ -27,15 +27,18 @@ async def async_setup_entry(
     if coordinator is None:
         return
 
-    entities = [
-        OctopusIntelligentBumpChargeSwitch(
-            coordinator,
-            device["id"],
-            device.get("name", "Véhicule"),
+    entities: list[SwitchEntity] = []
+    for device in coordinator.data.get("devices", []):
+        device_id = device.get("id")
+        if not device_id:
+            continue
+        device_name = device.get("name", "Véhicule")
+        entities.append(
+            OctopusIntelligentBumpChargeSwitch(coordinator, device_id, device_name)
         )
-        for device in coordinator.data.get("devices", [])
-        if device.get("id")
-    ]
+        entities.append(
+            OctopusIntelligentSmartControlSwitch(coordinator, device_id, device_name)
+        )
 
     if entities:
         async_add_entities(entities)
@@ -111,5 +114,71 @@ class OctopusIntelligentBumpChargeSwitch(CoordinatorEntity, SwitchEntity):
                 translation_domain=DOMAIN,
                 translation_key="cancel_boost_charge_failed",
                 translation_placeholders={"reasons": ", ".join(refusal_reasons)},
+            )
+        await self.coordinator.async_refresh_devices()
+
+
+class OctopusIntelligentSmartControlSwitch(CoordinatorEntity, SwitchEntity):
+    """Switch to suspend/restore Octopus's automatic smart control of a device.
+
+    Unlike boost charge, suspending smart control does not incur the
+    Intelligent tariff's boost-usage cost. It stops Octopus from
+    interrupting a charging session it did not schedule itself, at the
+    cost of losing Octopus's own schedule optimisation while suspended.
+    """
+
+    def __init__(
+        self,
+        coordinator: OctopusIntelligentDataUpdateCoordinator,
+        device_id: str,
+        device_name: str,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._attr_unique_id = f"{device_id}_smart_control"
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "smart_control"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_id)},
+            via_device=(DOMAIN, coordinator.account_number),
+            name=device_name,
+            model=device_name,
+        )
+
+    def _get_device_status(self) -> dict[str, Any]:
+        """Return the device payload from coordinator data."""
+        return self.coordinator.get_device(self._device_id) or {}
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if Octopus's automatic smart control is active (not suspended)."""
+        device = self._get_device_status()
+        status_data = device.get("status", {})
+        return not status_data.get("isSuspended", False)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Restore Octopus's automatic smart control."""
+        success = await self.coordinator.intelligent_client.unsuspend_smart_control(
+            self._device_id
+        )
+        if not success:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="update_smart_control_failed",
+                translation_placeholders={"device_id": self._device_id},
+            )
+        await self.coordinator.async_refresh_devices()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Suspend Octopus's automatic smart control."""
+        success = await self.coordinator.intelligent_client.suspend_smart_control(
+            self._device_id
+        )
+        if not success:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="update_smart_control_failed",
+                translation_placeholders={"device_id": self._device_id},
             )
         await self.coordinator.async_refresh_devices()

--- a/custom_components/octopus_french/translations/en.json
+++ b/custom_components/octopus_french/translations/en.json
@@ -764,6 +764,9 @@
             "name": "Refusal reasons"
           }
         }
+      },
+      "smart_control": {
+        "name": "Smart control"
       }
     },
     "number": {
@@ -795,6 +798,9 @@
     },
     "cancel_boost_charge_failed": {
       "message": "Failed to cancel boost charge: {reasons}."
+    },
+    "update_smart_control_failed": {
+      "message": "Failed to update smart control for device {device_id}."
     }
   }
 }

--- a/custom_components/octopus_french/translations/fr.json
+++ b/custom_components/octopus_french/translations/fr.json
@@ -792,6 +792,9 @@
             "name": "Raisons de refus"
           }
         }
+      },
+      "smart_control": {
+        "name": "Contrôle intelligent"
       }
     },
     "number": {
@@ -823,6 +826,9 @@
     },
     "cancel_boost_charge_failed": {
       "message": "Impossible d'annuler la charge boost : {reasons}."
+    },
+    "update_smart_control_failed": {
+      "message": "Impossible de mettre à jour le contrôle intelligent pour l'appareil {device_id}."
     }
   }
 }

--- a/tests/test_api_intelligent.py
+++ b/tests/test_api_intelligent.py
@@ -158,6 +158,61 @@ async def test_get_vehicle_charging_preferences(intelligent_client, mock_api_cli
 
 
 @pytest.mark.asyncio
+async def test_suspend_smart_control_success(intelligent_client, mock_api_client):
+    """Test suspending smart control."""
+    mock_api_client.execute_with_auth.return_value = {
+        "data": {
+            "updateDeviceSmartControl": {
+                "id": "abc-123",
+                "name": "Tesla Model 3",
+                "status": {"isSuspended": True},
+            }
+        }
+    }
+
+    result = await intelligent_client.suspend_smart_control("abc-123")
+
+    assert result is True
+    mock_api_client.execute_with_auth.assert_called_once()
+    _, variables = mock_api_client.execute_with_auth.call_args[0]
+    assert variables == {"deviceId": "abc-123", "action": "SUSPEND"}
+
+
+@pytest.mark.asyncio
+async def test_unsuspend_smart_control_success(intelligent_client, mock_api_client):
+    """Test restoring smart control."""
+    mock_api_client.execute_with_auth.return_value = {
+        "data": {
+            "updateDeviceSmartControl": {
+                "id": "abc-123",
+                "name": "Tesla Model 3",
+                "status": {"isSuspended": False},
+            }
+        }
+    }
+
+    result = await intelligent_client.unsuspend_smart_control("abc-123")
+
+    assert result is True
+    mock_api_client.execute_with_auth.assert_called_once()
+    _, variables = mock_api_client.execute_with_auth.call_args[0]
+    assert variables == {"deviceId": "abc-123", "action": "UNSUSPEND"}
+
+
+@pytest.mark.asyncio
+async def test_update_smart_control_error(intelligent_client, mock_api_client):
+    """Test smart control update failing."""
+    mock_api_client.execute_with_auth.return_value = {
+        "errors": [{"message": "Unauthorized."}],
+        "data": {"updateDeviceSmartControl": None},
+    }
+
+    result = await intelligent_client.suspend_smart_control("abc-123")
+
+    assert result is False
+
+
+@pytest.mark.asyncio
 async def test_get_flex_planned_dispatches(intelligent_client, mock_api_client):
     """Test getting planned dispatch windows."""
     mock_api_client.execute_with_auth.return_value = {

--- a/tests/test_api_intelligent.py
+++ b/tests/test_api_intelligent.py
@@ -4,7 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.octopus_french.api.intelligent import OctopusIntelligentApiClient
+from custom_components.octopus_french.api.intelligent import (
+    MUTATION_SET_DEVICE_PREFERENCES,
+    OctopusIntelligentApiClient,
+)
 
 
 @pytest.fixture
@@ -208,6 +211,70 @@ async def test_update_smart_control_error(intelligent_client, mock_api_client):
     }
 
     result = await intelligent_client.suspend_smart_control("abc-123")
+
+    assert result is False
+
+
+def test_mutation_set_device_preferences_uses_correct_graphql_types():
+    """setDevicePreferences must declare deviceId/time/max as ID!/Time!/Decimal!.
+
+    Regression test for a bug where these were declared String!/String!/Int!,
+    which Kraken rejected with an HTTP 400 on every call.
+    """
+    assert "$deviceId: ID!" in MUTATION_SET_DEVICE_PREFERENCES
+    assert "$time: Time!" in MUTATION_SET_DEVICE_PREFERENCES
+    assert "$max: Decimal!" in MUTATION_SET_DEVICE_PREFERENCES
+
+
+@pytest.mark.asyncio
+async def test_set_target_soc_success(intelligent_client, mock_api_client):
+    """Test setting target state of charge."""
+    mock_api_client.execute_with_auth.return_value = {
+        "data": {
+            "setDevicePreferences": {
+                "id": "abc-123",
+                "preferences": {"schedules": []},
+            }
+        }
+    }
+
+    result = await intelligent_client.set_target_soc("abc-123", 100, "07:00")
+
+    assert result is True
+    mock_api_client.execute_with_auth.assert_called_once()
+    _, variables = mock_api_client.execute_with_auth.call_args[0]
+    assert variables == {"deviceId": "abc-123", "time": "07:00", "max": 100}
+
+
+@pytest.mark.asyncio
+async def test_set_target_time_success(intelligent_client, mock_api_client):
+    """Test setting target charging time."""
+    mock_api_client.execute_with_auth.return_value = {
+        "data": {
+            "setDevicePreferences": {
+                "id": "abc-123",
+                "preferences": {"schedules": []},
+            }
+        }
+    }
+
+    result = await intelligent_client.set_target_time("abc-123", "22:30", 80)
+
+    assert result is True
+    mock_api_client.execute_with_auth.assert_called_once()
+    _, variables = mock_api_client.execute_with_auth.call_args[0]
+    assert variables == {"deviceId": "abc-123", "time": "22:30", "max": 80}
+
+
+@pytest.mark.asyncio
+async def test_set_device_preferences_error(intelligent_client, mock_api_client):
+    """Test setDevicePreferences failing (e.g. the wrong-GraphQL-type 400 this guards against)."""
+    mock_api_client.execute_with_auth.return_value = {
+        "errors": [{"message": "Variable '$deviceId' of type 'String!' used in position expecting type 'ID!'."}],
+        "data": {"setDevicePreferences": None},
+    }
+
+    result = await intelligent_client.set_target_soc("abc-123", 100, "07:00")
 
     assert result is False
 

--- a/tests/test_switch_smart_control.py
+++ b/tests/test_switch_smart_control.py
@@ -1,0 +1,105 @@
+"""Test the smart control switch."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.exceptions import HomeAssistantError
+import pytest
+
+from custom_components.octopus_french.coordinator_intelligent import OctopusIntelligentDataUpdateCoordinator
+from custom_components.octopus_french.switch import OctopusIntelligentSmartControlSwitch
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Mock coordinator."""
+    coordinator = MagicMock(spec=OctopusIntelligentDataUpdateCoordinator)
+    coordinator.account_number = "A-XXXX"
+    coordinator.data = {
+        "devices": [
+            {
+                "id": "abc-123",
+                "name": "Tesla Model 3",
+                "status": {
+                    "current": "LIVE",
+                    "currentState": "SMART_CONTROL_IN_PROGRESS",
+                    "isSuspended": False,
+                },
+            }
+        ],
+    }
+    coordinator.intelligent_client = MagicMock()
+    coordinator.intelligent_client.suspend_smart_control = AsyncMock(return_value=True)
+    coordinator.intelligent_client.unsuspend_smart_control = AsyncMock(return_value=True)
+    coordinator.async_refresh_devices = AsyncMock()
+    coordinator.get_device.side_effect = lambda device_id: next(
+        (device for device in coordinator.data["devices"] if device.get("id") == device_id), None
+    )
+    return coordinator
+
+
+@pytest.fixture
+def smart_control_switch(mock_coordinator):
+    """Create smart control switch."""
+    return OctopusIntelligentSmartControlSwitch(
+        mock_coordinator,
+        "abc-123",
+        "Tesla Model 3",
+    )
+
+
+@pytest.mark.asyncio
+async def test_smart_control_switch_on_restores_control(smart_control_switch, mock_coordinator):
+    """Turning the switch on unsuspends Octopus's smart control."""
+    await smart_control_switch.async_turn_on()
+
+    mock_coordinator.intelligent_client.unsuspend_smart_control.assert_called_once_with("abc-123")
+    mock_coordinator.async_refresh_devices.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_smart_control_switch_off_suspends_control(smart_control_switch, mock_coordinator):
+    """Turning the switch off suspends Octopus's smart control."""
+    await smart_control_switch.async_turn_off()
+
+    mock_coordinator.intelligent_client.suspend_smart_control.assert_called_once_with("abc-123")
+    mock_coordinator.async_refresh_devices.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_smart_control_switch_on_failure_raises(smart_control_switch, mock_coordinator):
+    """A failed unsuspend raises and does not refresh."""
+    mock_coordinator.intelligent_client.unsuspend_smart_control.return_value = False
+
+    with pytest.raises(HomeAssistantError):
+        await smart_control_switch.async_turn_on()
+
+    mock_coordinator.async_refresh_devices.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_smart_control_switch_off_failure_raises(smart_control_switch, mock_coordinator):
+    """A failed suspend raises and does not refresh."""
+    mock_coordinator.intelligent_client.suspend_smart_control.return_value = False
+
+    with pytest.raises(HomeAssistantError):
+        await smart_control_switch.async_turn_off()
+
+    mock_coordinator.async_refresh_devices.assert_not_called()
+
+
+def test_smart_control_switch_is_on_when_not_suspended(smart_control_switch, mock_coordinator):
+    """is_on is True when Octopus's control is active (not suspended)."""
+    mock_coordinator.data["devices"][0]["status"]["isSuspended"] = False
+    assert smart_control_switch.is_on is True
+
+
+def test_smart_control_switch_is_off_when_suspended(smart_control_switch, mock_coordinator):
+    """is_on is False once smart control has been suspended."""
+    mock_coordinator.data["devices"][0]["status"]["isSuspended"] = True
+    assert smart_control_switch.is_on is False
+
+
+def test_smart_control_switch_is_on_defaults_true_when_unknown(smart_control_switch, mock_coordinator):
+    """Absent isSuspended defaults to control-active (fail-safe: don't assume suspended)."""
+    del mock_coordinator.data["devices"][0]["status"]["isSuspended"]
+    assert smart_control_switch.is_on is True


### PR DESCRIPTION
## Context

While diagnosing why the integration stopped loading entirely on my instance, I found several `except A, B:` (Python 2 syntax, invalid in Python 3) introduced by 406719b in `octopus_french.py`, `sensors/electricity.py` and `sensors/gas.py`, plus type annotations using a `TYPE_CHECKING`-only import without `from __future__ import annotations` in `coordinator.py`, `coordinator_intelligent.py` and `api/intelligent.py`. Result: `SyntaxError`/`NameError` at import time, the integration never sets up (only HACS's own `update` entity survives).

Digging further, a real need emerged: my car charges on solar surplus, driven by a local Home Assistant automation. Octopus Intelligent systematically cuts any charging session started outside its own scheduled windows (~2 min in), including solar-surplus-driven sessions. The only existing workaround (`bump_charge` / boost) has a cost (billed beyond 2 uses/month) and isn't meant for this. The Kraken `updateDeviceSmartControl` mutation (action `SUSPEND`/`UNSUSPEND`) lets you temporarily disable Octopus's automatic control without that cost — it's the same mechanism the Octopus mobile app itself uses for the "Smart control" toggle.

## Fixes

- **fix: Python 2 syntax in `except` blocks** — 5 occurrences fixed (`except A, B:` → `except (A, B):`) across `octopus_french.py`, `sensors/electricity.py`, `sensors/gas.py`.
- **fix: `NameError` on `TYPE_CHECKING` annotations** — added `from __future__ import annotations` to the 3 affected files.
- **fix: wrong GraphQL variable types in `setDevicePreferences`** — `$deviceId`/`$time`/`$max` were declared `String!`/`String!`/`Int!` while Kraken's schema expects `ID!`/`Time!`/`Decimal!`. This mutation (used by `set_target_soc`/`set_target_time`) failed every call with an HTTP 400 — confirmed against the live schema's error response.

## Feature added

- **New `switch.<vehicle>_smart_control` entity** (translated: "Smart control") — toggles `updateDeviceSmartControl(action: SUSPEND/UNSUSPEND)`. Lets a third-party automation (solar charging, etc.) cleanly suspend Octopus's control for the duration of a session, without `bump_charge`'s side effects (cost, forced charge-state change).
- Added `status.isSuspended` to the `devices` query so the switch reflects real state.

## Tests

- Isolated environment (`uv` + Python 3.13 + `pytest-homeassistant-custom-component` + the manifest's real dependencies), since neither syntax bug was detectable without actually executing the code.
- 144 existing tests: 0% passing before the fix (collection failure, the whole module refused to import), 100% after.
- 25 new tests (API client + switch) for `suspend_smart_control`/`unsuspend_smart_control` and the switch entity (success, failure, refusal, `is_on` attribute).
- Tested live on my own instance (active `octopus_french` account, linked vehicle): `switch.turn_off` on the entity does flip the Octopus mobile app to "Smart control disabled", `switch.turn_on` restores "Optimised control available".

## Checklist

- [x] Unit tests
- [x] Tested live (linked account + vehicle)
- [x] No regression on existing code (144 pre-existing tests pass)
- [x] Conventional commit

Closes #55 — same root cause: `setDevicePreferences` declares `$deviceId`/`$time`/`$max` as `String!`/`String!`/`Int!`, Kraken expects `ID!`/`Time!`/`Decimal!`, every call 400s and gets misreported as "Unable to reach GraphQL endpoint after retries" by the retry wrapper. Fixed in the third commit, with regression tests.