### PR TITLE
fix: handle explicit null periodStartAt in Tempo colour detection

### DIFF
--- a/custom_components/octopus_french/octopus_french.py
+++ b/custom_components/octopus_french/octopus_french.py
@@ -1131,7 +1131,7 @@ class OctopusFrenchApiClient:
 
                 color = self._REGISTER_CODE_TO_COLOR.get(effective_code)
                 if color:
-                    node_date = node.get("periodStartAt", "")[:10]
+                    node_date = (node.get("periodStartAt") or "")[:10]
                     color_key = (
                         "tempo_color_tomorrow"
                         if node_date == tomorrow_str
@@ -1142,7 +1142,7 @@ class OctopusFrenchApiClient:
             elif effective_code in self._CALENDAR_COLOR_TO_COLOR:
                 tariff_type = "TEMPO"
                 color = self._CALENDAR_COLOR_TO_COLOR[effective_code]
-                node_date = node.get("periodStartAt", "")[:10]
+                node_date = (node.get("periodStartAt") or "")[:10]
                 color_key = (
                     "tempo_color_tomorrow"
                     if node_date == tomorrow_str

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -371,6 +371,31 @@ class TestElectricityIndexTempo:
         assert result["tempo_color"] == "ROUGE"
 
     @pytest.mark.asyncio
+    async def test_null_period_start_at_does_not_crash(self) -> None:
+        """A node with periodStartAt=None must not raise TypeError.
+
+        Regression test for issue #57: provisional/not-yet-settled Tempo
+        index entries can come back with an explicit JSON null for
+        periodStartAt. node.get("periodStartAt", "") only substitutes the
+        default for a *missing* key, not an explicit None, so slicing it
+        raised "'NoneType' object is not subscriptable" and broke the
+        entire initial data fetch (ConfigEntryNotReady) for every OctoTempo
+        user hitting this on any given day.
+        """
+        from custom_components.octopus_french.octopus_french import OctopusFrenchApiClient
+
+        client = OctopusFrenchApiClient.__new__(OctopusFrenchApiClient)
+        response = self._make_index_response("ROUGE")
+        response["data"]["electricityReading"]["edges"][0]["node"]["periodStartAt"] = None
+
+        with patch.object(client, "execute_with_auth", return_value=response):
+            result = await client.get_electricity_index("ACC123", "PRM456")
+
+        assert result is not None
+        assert result["tariff_type"] == TARIFF_TYPE_TEMPO
+        assert result["tempo_color"] == "ROUGE"
+
+    @pytest.mark.asyncio
     async def test_hp_class_still_detected_as_hphc(self) -> None:
         """Une classe HP classique doit toujours être détectée comme HPHC."""
         from custom_components.octopus_french.octopus_french import OctopusFrenchApiClient


### PR DESCRIPTION
## Context

Closes #57.

`get_electricity_index()` has two occurrences of `node.get("periodStartAt", "")[:10]`. `dict.get(key, default)` only substitutes the default when the key is *absent* — the Kraken API returns `periodStartAt: null` (present, explicit null) for provisional/not-yet-settled Tempo index entries, so `.get()` returns `None` and `None[:10]` raises exactly `'NoneType' object is not subscriptable`, matching the error in #57 verbatim.

That exception propagates out of `get_electricity_index()`, is caught by the generic `except Exception as err: raise UpdateFailed(...)` in the coordinator, then re-wrapped as `ConfigEntryNotReady("Initial data fetch failed: ...")` in `__init__.py` — which is exactly the error chain reported in the issue. It breaks config entry setup entirely (not just one sensor) for any OctoTempo user who hits a null entry on a given poll.

Introduced in c3c69ae (3.3.0 OctoTempo support), consistent with the reporter saying it started "depuis la version 3.3.1".

## Fix

Both occurrences changed from:
```python
node_date = node.get("periodStartAt", "")[:10]
```
to:
```python
node_date = (node.get("periodStartAt") or "")[:10]
```
`or ""` catches both the missing-key and explicit-null cases.

## Tests

- New regression test (`test_null_period_start_at_does_not_crash`) reproducing the exact null-periodStartAt payload shape and asserting `get_electricity_index()` no longer raises and still detects the Tempo colour correctly.
- Full `test_tempo.py` suite (37 tests) passes.

Note: this branch is based on current `main`, which still has an unrelated pre-existing bug (`except A, B:` Python 2 syntax in a few files, already fixed in #58) that blocks the whole test suite from even collecting. I patched it locally only to run tests, then reverted that patch before committing — this PR's diff is scoped to the null-check fix only. Once #58 lands, `main` will be fully testable again independent of this PR.

## Checklist

- [x] Unit tests
- [x] No regression on existing code (`test_tempo.py` fully green)
- [x] Conventional commit