### PR TITLE
fix: scope electricity readings/index per contract (PRM)

### DIFF
--- a/custom_components/octopus_french/coordinator.py
+++ b/custom_components/octopus_french/coordinator.py
@@ -73,9 +73,9 @@ class OctopusFrenchDataUpdateCoordinator(DataUpdateCoordinator):
         ]
 
         electricity_supply_points = supply_points["electricity"]
-        electricity_meter_id = (
-            electricity_supply_points[0].get("prm") if electricity_supply_points else None
-        )
+        electricity_meter_ids = [
+            sp.get("prm") for sp in electricity_supply_points if sp.get("prm")
+        ]
         gas_supply_points = supply_points.get("gas", [])
         gas_meter_id = gas_supply_points[0].get("prm") if gas_supply_points else None
 
@@ -86,29 +86,40 @@ class OctopusFrenchDataUpdateCoordinator(DataUpdateCoordinator):
         date_end = now.isoformat()
         gas_start = (today_midnight - timedelta(days=365)).isoformat()
 
-        async def fetch_electricity() -> tuple[list, Any]:
-            if not electricity_meter_id:
-                return [], None
-
+        async def fetch_electricity_for_prm(prm_id: str) -> tuple[str, list, Any]:
             try:
                 readings = await self.api_client.get_energy_readings(
                     account_id,
                     electricity_start,
                     date_end,
-                    electricity_meter_id,
+                    prm_id,
                     utility_type="electricity",
                     reading_frequency="DAY_INTERVAL",
                     reading_quality="ACTUAL",
                     first=100,
                 )
                 index = await self.api_client.get_electricity_index(
-                    account_number, electricity_meter_id
+                    account_number, prm_id
                 )
             except OctopusConnectionError as err:
-                _LOGGER.warning("Failed to fetch electricity data: %s", err)
-                return [], None
+                _LOGGER.warning(
+                    "Failed to fetch electricity data for PRM %s: %s", prm_id, err
+                )
+                return prm_id, [], None
             else:
-                return readings, index
+                return prm_id, readings, index
+
+        async def fetch_electricity() -> dict[str, dict[str, Any]]:
+            if not electricity_meter_ids:
+                return {}
+
+            results = await asyncio.gather(
+                *(fetch_electricity_for_prm(prm_id) for prm_id in electricity_meter_ids)
+            )
+            return {
+                prm_id: {"readings": readings, "index": index}
+                for prm_id, readings, index in results
+            }
 
         async def fetch_gas() -> list:
             if not gas_meter_id:
@@ -138,28 +149,12 @@ class OctopusFrenchDataUpdateCoordinator(DataUpdateCoordinator):
                 return {}
 
         (
-            (electricity_readings, elec_index),
+            electricity_by_prm,
             gas,
             payment_requests,
         ) = await asyncio.gather(fetch_electricity(), fetch_gas(), fetch_payments())
 
-        tariffs = None
-        agreements = account_data.get("agreements", [])
-        for agreement in agreements:
-            if agreement.get("prm") == electricity_meter_id and agreement.get("is_active"):
-                tariffs = agreement.get("tariffs")
-                break
-        if tariffs is None:
-            for agreement in agreements:
-                if agreement.get("is_active"):
-                    tariffs = agreement.get("tariffs")
-                    break
-
-        account_data["electricity"] = {
-            "readings": electricity_readings,
-            "index": elec_index,
-            "tariffs": tariffs,
-        }
+        account_data["electricity_by_prm"] = electricity_by_prm
         account_data["gas"] = gas
         account_data["payment_requests"] = payment_requests
 

--- a/custom_components/octopus_french/sensor.py
+++ b/custom_components/octopus_french/sensor.py
@@ -128,7 +128,7 @@ async def async_setup_entry(
             OctopusLatestReadingSensor(coordinator, prm_id, LATEST_READING_SENSOR)
         )
 
-        index_data = coordinator.data.get("electricity", {}).get("index")
+        index_data = coordinator.data.get("electricity_by_prm", {}).get(prm_id, {}).get("index")
         if index_data:
             index_tariff_type = index_data.get("tariff_type")
 
@@ -190,7 +190,7 @@ def _detect_tariff_type_for_meter(data: dict, prm_id: str) -> str:
             if len(codes) == 1:
                 return "BASE"
 
-        electricity_readings = data.get("electricity", {}).get("readings", [])
+        electricity_readings = data.get("electricity_by_prm", {}).get(prm_id, {}).get("readings", [])
         if electricity_readings:
             latest_reading = electricity_readings[-1]
             statistics = (latest_reading.get("metaData") or {}).get("statistics", [])
@@ -209,7 +209,7 @@ def _detect_tariff_type_for_meter(data: dict, prm_id: str) -> str:
                 if any(kw in code for kw in TEMPO_PRODUCT_CODE_KEYWORDS):
                     return TARIFF_TYPE_TEMPO
 
-        index = data.get("electricity", {}).get("index") or {}
+        index = data.get("electricity_by_prm", {}).get(prm_id, {}).get("index") or {}
         tariff_type = index.get("tariff_type")
         if tariff_type in ("BASE", "HPHC", TARIFF_TYPE_TEMPO):
             return tariff_type

--- a/custom_components/octopus_french/sensors/electricity.py
+++ b/custom_components/octopus_french/sensors/electricity.py
@@ -103,7 +103,7 @@ class OctopusElectricitySensor(CoordinatorEntity, SensorEntity):
     async def _async_do_import_statistics(self) -> None:
         """Perform the actual statistics import."""
         key = self._sensor_config.key
-        readings = self.coordinator.data.get("electricity", {}).get("readings", [])
+        readings = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {}).get("readings", [])
 
         if not readings:
             return
@@ -333,7 +333,7 @@ class OctopusElectricitySensor(CoordinatorEntity, SensorEntity):
 
     def _calculate_monthly_subscription_fallback(self) -> float:
         """Fallback: Calculate monthly subscription from daily readings."""
-        readings = self.coordinator.data.get("electricity", {}).get("readings", [])
+        readings = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {}).get("readings", [])
 
         if not readings:
             return 0.0
@@ -362,7 +362,7 @@ class OctopusElectricitySensor(CoordinatorEntity, SensorEntity):
     def _calculate_monthly_total(self) -> float:
         """Calculate monthly total."""
         key = self._sensor_config.key
-        readings = self.coordinator.data.get("electricity", {}).get("readings", [])
+        readings = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {}).get("readings", [])
 
         if not readings:
             return 0.0
@@ -538,7 +538,7 @@ class OctopusElectricitySensor(CoordinatorEntity, SensorEntity):
                     )
                     attributes["next_payment_date"] = next_payment.get("date")
             else:
-                readings = self.coordinator.data.get("electricity", {}).get(
+                readings = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {}).get(
                     "readings", []
                 )
                 days_with_subscription = 0
@@ -572,7 +572,7 @@ class OctopusElectricitySensor(CoordinatorEntity, SensorEntity):
             return attributes
 
         if key.startswith(("energy_", "cost_")):
-            readings = self.coordinator.data.get("electricity", {}).get("readings", [])
+            readings = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {}).get("readings", [])
 
             return {
                 "current_month": self._current_month,
@@ -743,7 +743,7 @@ class OctopusLatestReadingSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the latest reading value."""
-        electricity_data = self.coordinator.data.get("electricity", {})
+        electricity_data = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {})
         readings = electricity_data.get("readings", [])
 
         if not readings:
@@ -756,7 +756,7 @@ class OctopusLatestReadingSensor(CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes for the latest reading."""
-        electricity_data = self.coordinator.data.get("electricity", {})
+        electricity_data = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {})
         readings = electricity_data.get("readings", [])
 
         if not readings:
@@ -878,7 +878,7 @@ class OctopusElectricityIndexSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the index end value."""
-        index_data = self.coordinator.data.get("electricity", {}).get("index")
+        index_data = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {}).get("index")
 
         if not index_data:
             return None
@@ -889,7 +889,7 @@ class OctopusElectricityIndexSensor(CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes."""
-        index_data = self.coordinator.data.get("electricity", {}).get("index")
+        index_data = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {}).get("index")
 
         if not index_data:
             return {}
@@ -910,7 +910,7 @@ class OctopusElectricityIndexSensor(CoordinatorEntity, SensorEntity):
         """Return if entity is available."""
         if not super().available:
             return False
-        index_data = self.coordinator.data.get("electricity", {}).get("index")
+        index_data = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {}).get("index")
         if not index_data:
             return False
         return self._index_type in index_data
@@ -941,7 +941,7 @@ class OctopusTempoColorSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> str | None:
         """Return the Tempo color from the electricity index."""
-        index_data = self.coordinator.data.get("electricity", {}).get("index")
+        index_data = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {}).get("index")
         if not index_data:
             return None
         color_key = "tempo_color_tomorrow" if self._is_tomorrow else "tempo_color"
@@ -950,7 +950,7 @@ class OctopusTempoColorSensor(CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes."""
-        index_data = self.coordinator.data.get("electricity", {}).get("index") or {}
+        index_data = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {}).get("index") or {}
         return {
             "prm_id": self._prm_id,
             "period_start": index_data.get("period_start"),
@@ -966,7 +966,7 @@ class OctopusTempoColorSensor(CoordinatorEntity, SensorEntity):
         ):
             return False
         if self._is_tomorrow:
-            index_data = self.coordinator.data.get("electricity", {}).get("index") or {}
+            index_data = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {}).get("index") or {}
             return "tempo_color_tomorrow" in index_data
         return True
 
@@ -1010,7 +1010,7 @@ class OctopusTempoCurrentRateSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the active Tempo rate (€/kWh) for the current color and HC/HP period."""
-        index_data = self.coordinator.data.get("electricity", {}).get("index") or {}
+        index_data = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {}).get("index") or {}
         color = index_data.get("tempo_color")
         if not color:
             return None
@@ -1030,7 +1030,7 @@ class OctopusTempoCurrentRateSensor(CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return current color and period information."""
-        index_data = self.coordinator.data.get("electricity", {}).get("index") or {}
+        index_data = self.coordinator.data.get("electricity_by_prm", {}).get(self._prm_id, {}).get("index") or {}
         color = index_data.get("tempo_color")
         is_hc = self._is_currently_hc() if color else None
         return {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,120 @@
+"""Tests for OctopusFrenchDataUpdateCoordinator's per-contract (PRM) data fetch."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.octopus_french.coordinator import OctopusFrenchDataUpdateCoordinator
+
+
+def _make_coordinator(api_client: MagicMock) -> OctopusFrenchDataUpdateCoordinator:
+    """Instantiate the coordinator without going through HA's heavy __init__."""
+    coordinator = OctopusFrenchDataUpdateCoordinator.__new__(OctopusFrenchDataUpdateCoordinator)
+    coordinator.api_client = api_client
+    coordinator.account_number = "A-XXXX"
+    return coordinator
+
+
+def _make_api_client(electricity_supply_points: list[dict]) -> MagicMock:
+    """Build a fake API client whose per-PRM responses are keyed by market_supply_point_id."""
+    client = MagicMock()
+    client.get_account_data = AsyncMock(
+        return_value={
+            "account_id": "PROP-1",
+            "account_number": "A-XXXX",
+            "ledgers": {},
+            "supply_points": {"electricity": electricity_supply_points, "gas": []},
+            "agreements": [],
+        }
+    )
+
+    async def fake_get_energy_readings(
+        property_id, start_at, end_at, market_supply_point_id, **kwargs
+    ):
+        return [{"prm": market_supply_point_id, "value": f"readings-{market_supply_point_id}"}]
+
+    async def fake_get_electricity_index(account_number, prm_id):
+        return {"tariff_type": "BASE", "prm": prm_id}
+
+    client.get_energy_readings = AsyncMock(side_effect=fake_get_energy_readings)
+    client.get_electricity_index = AsyncMock(side_effect=fake_get_electricity_index)
+    client.get_all_payment_requests = AsyncMock(return_value={})
+    return client
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_data_scopes_readings_and_index_per_prm() -> None:
+    """Two electricity PRMs on the same account must each get their own readings/index.
+
+    Regression test for issue #56: previously only
+    electricity_supply_points[0] was ever fetched, and every PRM's sensors
+    read from a single shared account_data["electricity"] blob.
+    """
+    api_client = _make_api_client(
+        [
+            {"prm": "PRM1", "distributorStatus": "ACTIF"},
+            {"prm": "PRM2", "distributorStatus": "ACTIF"},
+        ]
+    )
+    coordinator = _make_coordinator(api_client)
+
+    result = await coordinator._fetch_all_data()
+
+    assert set(result["electricity_by_prm"].keys()) == {"PRM1", "PRM2"}
+
+    prm1_data = result["electricity_by_prm"]["PRM1"]
+    prm2_data = result["electricity_by_prm"]["PRM2"]
+
+    assert prm1_data["readings"] == [{"prm": "PRM1", "value": "readings-PRM1"}]
+    assert prm2_data["readings"] == [{"prm": "PRM2", "value": "readings-PRM2"}]
+    assert prm1_data["index"] == {"tariff_type": "BASE", "prm": "PRM1"}
+    assert prm2_data["index"] == {"tariff_type": "BASE", "prm": "PRM2"}
+
+    # Both PRMs must have been queried, each with its own market_supply_point_id.
+    queried_prms = {
+        call.args[3] for call in api_client.get_energy_readings.await_args_list
+    }
+    assert queried_prms == {"PRM1", "PRM2"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_data_single_prm_still_works() -> None:
+    """A single-contract account (the common case) still gets its data."""
+    api_client = _make_api_client([{"prm": "PRM1", "distributorStatus": "ACTIF"}])
+    coordinator = _make_coordinator(api_client)
+
+    result = await coordinator._fetch_all_data()
+
+    assert set(result["electricity_by_prm"].keys()) == {"PRM1"}
+    assert result["electricity_by_prm"]["PRM1"]["readings"] == [
+        {"prm": "PRM1", "value": "readings-PRM1"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_data_no_electricity_supply_points() -> None:
+    """An account with no electricity supply point must not crash and returns no data."""
+    api_client = _make_api_client([])
+    coordinator = _make_coordinator(api_client)
+
+    result = await coordinator._fetch_all_data()
+
+    assert result["electricity_by_prm"] == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_data_filters_out_terminated_meters() -> None:
+    """A RESIL (terminated) meter must not be fetched or appear in electricity_by_prm."""
+    api_client = _make_api_client(
+        [
+            {"prm": "PRM1", "distributorStatus": "ACTIF"},
+            {"prm": "PRM_TERMINATED", "distributorStatus": "RESIL"},
+        ]
+    )
+    coordinator = _make_coordinator(api_client)
+
+    result = await coordinator._fetch_all_data()
+
+    assert set(result["electricity_by_prm"].keys()) == {"PRM1"}

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -135,7 +135,7 @@ def test_detect_tariff_type_with_null_product_code() -> None:
     # _extract_agreements always sets product.code, possibly to None, so the
     # `.get("code", "")` default never fired and None.upper() used to raise.
     data = {
-        "electricity": {"readings": []},
+        "electricity_by_prm": {"12345": {"readings": []}},
         "agreements": [
             {"prm": "12345", "is_active": True, "product": {"code": None}},
         ],
@@ -147,7 +147,7 @@ def test_detect_tariff_type_with_null_product_code() -> None:
 def test_detect_tariff_type_with_null_metadata() -> None:
     """A reading whose metaData is null leaves the tariff undetected."""
     data = {
-        "electricity": {"readings": [{"metaData": None}]},
+        "electricity_by_prm": {"12345": {"readings": [{"metaData": None}]}},
         "agreements": [],
     }
 

--- a/tests/test_statistics_import.py
+++ b/tests/test_statistics_import.py
@@ -58,7 +58,9 @@ def _make_sensor(key: str, readings: list[dict]) -> OctopusElectricitySensor:
     sensor._last_imported_date = None
     sensor._import_in_progress = False
     sensor.hass = MagicMock()
-    sensor.coordinator = SimpleNamespace(data={"electricity": {"readings": readings}})
+    sensor.coordinator = SimpleNamespace(
+        data={"electricity_by_prm": {"PRM1": {"readings": readings}}}
+    )
     return sensor
 
 

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -63,11 +63,13 @@ class TestDetectTariffTypeTempo:
         """Construit un faux objet coordinator.data."""
         stats = [{"label": lbl, "value": "1.0"} for lbl in stat_labels]
         return {
-            "electricity": {
-                "readings": [
-                    {"startAt": "2026-05-01T00:00:00", "metaData": {"statistics": stats}}
-                ],
-                "index": None,
+            "electricity_by_prm": {
+                prm_id: {
+                    "readings": [
+                        {"startAt": "2026-05-01T00:00:00", "metaData": {"statistics": stats}}
+                    ],
+                    "index": None,
+                }
             },
             "agreements": [
                 {
@@ -123,24 +125,59 @@ class TestDetectTariffTypeTempo:
         assert result == TARIFF_TYPE_TEMPO
 
     def test_other_prm_not_detected_as_tempo(self) -> None:
-        """Le produit TEMPO d'un autre PRM ne doit pas affecter le PRM cible."""
-        data = self._make_data(
-            stat_labels=["BASE"],
-            prm_id="OTHER_PRM",
-            product_code="FR_TEMPO",
-        )
-        data["electricity"]["readings"][0]["metaData"]["statistics"] = [
-            {"label": "BASE", "value": "1.0"}
-        ]
+        """Le produit TEMPO d'un autre PRM ne doit pas affecter le PRM cible.
+
+        Regression test for issue #56: two electricity contracts on the same
+        account must not bleed readings/index/product-code into each other.
+        """
+        data = {
+            "electricity_by_prm": {
+                "TEST_PRM": {
+                    "readings": [
+                        {
+                            "startAt": "2026-05-01T00:00:00",
+                            "metaData": {"statistics": [{"label": "BASE", "value": "1.0"}]},
+                        }
+                    ],
+                    "index": None,
+                },
+                "OTHER_PRM": {
+                    "readings": [
+                        {
+                            "startAt": "2026-05-01T00:00:00",
+                            "metaData": {
+                                "statistics": [
+                                    {
+                                        "label": "CONSUMPTION_OCTOFLEX_4_V4_HPE_0.0_37.0",
+                                        "value": "1.0",
+                                    }
+                                ]
+                            },
+                        }
+                    ],
+                    "index": None,
+                },
+            },
+            "agreements": [
+                {
+                    "prm": "OTHER_PRM",
+                    "is_active": True,
+                    "product": {"code": "FR_TEMPO", "display_name": "Test"},
+                    "tariffs": {},
+                }
+            ],
+        }
         result = _detect_tariff_type_for_meter(data, "TEST_PRM")
         assert result == "BASE"
 
     def test_no_readings_fallback_to_index(self) -> None:
         """Sans readings, on utilise l'index électrique."""
         data = {
-            "electricity": {
-                "readings": [],
-                "index": {"tariff_type": TARIFF_TYPE_TEMPO, "tempo_color": "ETE"},
+            "electricity_by_prm": {
+                "TEST_PRM": {
+                    "readings": [],
+                    "index": {"tariff_type": TARIFF_TYPE_TEMPO, "tempo_color": "ETE"},
+                }
             },
             "agreements": [],
         }
@@ -465,8 +502,10 @@ class TestTempoCurrentRateSensor:
         coordinator = MagicMock()
         coordinator.last_update_success = True
         coordinator.data = {
-            "electricity": {
-                "index": {"tempo_color": tempo_color} if tempo_color else {},
+            "electricity_by_prm": {
+                prm_id: {
+                    "index": {"tempo_color": tempo_color} if tempo_color else {},
+                }
             },
             "agreements": [
                 {
@@ -593,11 +632,13 @@ class TestLatestReadingTempoAttributes:
                 }
             ]
         coordinator.data = {
-            "electricity": {
-                "readings": [
-                    {"startAt": "2026-06-13T00:00:00", "value": "15.0",
-                     "metaData": {"statistics": stats}}
-                ],
+            "electricity_by_prm": {
+                prm_id: {
+                    "readings": [
+                        {"startAt": "2026-06-13T00:00:00", "value": "15.0",
+                         "metaData": {"statistics": stats}}
+                    ],
+                }
             },
             "agreements": agreements,
         }


### PR DESCRIPTION
## Context

Closes #56.

An account with 2+ electricity supply points (2 contracts, 2 Linky meters, as reported) only ever fetched and stored data for the *first* one: `coordinator._fetch_all_data()` used `electricity_supply_points[0].get("prm")` and stashed the result in a single flat `account_data["electricity"]` dict. Every sensor entity — regardless of which PRM it was actually instantiated for — read from that same shared blob. That exactly explains both symptoms in the issue: the second contract's entities showing data that "looks similar" to the first (because it literally is the first contract's data), and the contract without HP/HC tariffs appearing to have zero index data if it happened to be the one silently starved of its own fetch.

Turned out narrower in scope than it first looked: tariff-rate lookups were already correctly scoped per PRM (they read `agreement.get("tariffs")` filtered by `prm` from `coordinator.data["agreements"]` directly, at every call site). Only `readings` and `index` — the two fields actually stored in that flat, single-PRM `account_data["electricity"]` dict — needed fixing.

## Fix

- `coordinator.py`: `fetch_electricity()` now fetches readings + index concurrently for *every* electricity PRM (not just the first), storing the result as `account_data["electricity_by_prm"][prm_id] = {"readings": ..., "index": ...}` instead of one flat `account_data["electricity"]`.
- `sensor.py`, `sensors/electricity.py`: every read site (15 in `sensors/electricity.py`, 3 in `sensor.py` including `_detect_tariff_type_for_meter`) updated to key off `electricity_by_prm[self._prm_id]` / `electricity_by_prm[prm_id]` instead of the shared flat dict.
- Dropped the old `account_data["electricity"]["tariffs"]` computation along with the flat dict — it was dead code, nothing read it (all real tariff lookups already go through `agreements` directly).

## Tests

- Updated fixtures in `test_tempo.py`, `test_extractors.py`, `test_statistics_import.py` to the new `electricity_by_prm` shape — several of these were previously exercising the buggy shared-blob path without actually proving per-PRM isolation (the old single-blob fixture couldn't tell the difference).
- Rewrote `test_other_prm_not_detected_as_tempo` into a genuine regression test for #56: two PRMs, each with their own readings in `electricity_by_prm`, only one with a TEMPO product agreement — asserts the *other* PRM's detection isn't contaminated.
- Full suite: 134 passed. The only failures are 18 pre-existing `async def` collection errors in `test_auth.py`/`test_config_flow.py` unrelated to this change (a test-harness `asyncio_mode` registration issue, reproducible on unmodified `main`).
- This branch is based on current `main`, which has an unrelated pre-existing syntax bug (`except A, B:`, already fixed in #58) blocking the whole suite from collecting at all — patched locally only to run tests, reverted before committing, so this PR's diff is scoped to the multi-contract fix only.

## Checklist

- [x] Unit tests
- [x] No regression on existing code (134/134 non-pre-existing-broken tests pass)
- [x] Conventional commit