### PR TITLE
ci: cible Python 3.14 uniquement (HA >= 2026.3 exige 3.14.2)

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -40,8 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # 3.13 = runtime Home Assistant (bloquant), 3.14 = compatibilité future.
-        python-version: ["3.13", "3.14"]
+        # 3.14 = runtime Home Assistant (≥ 2026.3 exige Python 3.14.2).
+        python-version: ["3.14"]
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ha-octopus-french"
 version = "4.0.0"
 description = "Octopus French custom integration for Home Assistant"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.14"
 license = { text = "MIT" }
 authors = [
     { name = "Domodom30" }
@@ -18,6 +18,8 @@ authors = [
 ###############################################################################
 
 [tool.ruff]
+# Runtime = Python 3.14, mais on garde py313 comme cible de syntaxe pour ne pas
+# adopter la syntaxe PEP 758 (`except A, B:` sans parenthèses), peu lisible.
 target-version = "py313"
 line-length = 88
 
@@ -46,7 +48,7 @@ quote-style = "double"
 ###############################################################################
 
 [tool.pyright]
-pythonVersion = "3.13"
+pythonVersion = "3.14"
 # basic : le code livré passe proprement (imports/appels/attributs/types restent des erreurs).
 # strict ajoutait ~700 remontées "type inconnu" sans valeur ici (HA partiellement typé + mocks).
 typeCheckingMode = "basic"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,8 @@
 #
 # pytest-homeassistant-custom-component épingle exactement homeassistant et pytest.
 # La version ci-dessous correspond à Home Assistant 2026.3.2 (schéma 0.13.PATCH).
+# NB : Home Assistant >= 2026.3 exige Python >= 3.14.2 (les tests ne tournent donc
+# plus sous Python 3.13).
 # Pour la mettre à jour, aligner sur la version de HA visée puis :
 #   pip install pytest-homeassistant-custom-component -c <(echo "homeassistant==<version>")
 #


### PR DESCRIPTION
## Problème

Depuis le merge de la v4.0.0, la CI `Validate and Release` échoue (sur `main` et sur la PR) à l'étape d'installation des dépendances de test :

```
ERROR: No matching distribution found for homeassistant==2026.3.2
  (… 2026.3.2 Requires-Python >=3.14.2 …)
```

Home Assistant **2026.3+ exige Python ≥ 3.14.2**. Le pin `homeassistant==2026.3.2` (imposé par `pytest-homeassistant-custom-component==0.13.318`) n'est donc pas installable sous Python 3.13. La matrice CI testait encore `["3.13", "3.14"]` : le job 3.13 échouait, le fail-fast annulait le job 3.14, et le job `release` (dépendant de `lint-test`) était skippé — aucune release v4.0.0 n'a été créée.

## Correctif

- **Workflow** : matrice réduite à Python `3.14`.
- **pyproject** : `requires-python = ">=3.14"`, pyright `pythonVersion = "3.14"`. `target-version` ruff reste `py313` volontairement, pour ne pas adopter la syntaxe PEP 758 (`except A, B:` sans parenthèses).
- **requirements_test** : note sur le minimum Python 3.14.2 (pins inchangés, ils sont cohérents entre eux).

Aucune modification de code applicatif ni de tests.

## Vérifié en local (Python 3.14.2)

- `pytest` : 174 tests OK
- `ruff check` / `ruff format --check` : propres
- `pyright` : 0 erreur

Une fois mergé, le job `release` recréera automatiquement le tag `v4.0.0` + la GitHub Release.