### PR TITLE
release: v4.0.1 — fix relevés par contrat (issue #56)

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -40,8 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # 3.13 = runtime Home Assistant (bloquant), 3.14 = compatibilité future.
-        python-version: ["3.13", "3.14"]
+        # 3.14 = runtime Home Assistant (≥ 2026.3 exige Python 3.14.2).
+        python-version: ["3.14"]
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.0.1] - 2026-07-23
+
+### 🐛 Corrections
+
+- **Comptes multi-Linky (issue #56)** : sur un compte à plusieurs contrats/logements, les relevés de consommation sont désormais récupérés sur la **bonne propriété** pour chaque point de livraison. Les données ne sont plus mélangées ni dupliquées entre les deux compteurs.
+
+---
+
 ## [4.0.0] - 2026-07-22
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/A1V11ZZTPI)

--- a/custom_components/octopus_french/__init__.py
+++ b/custom_components/octopus_french/__init__.py
@@ -165,14 +165,7 @@ async def async_setup_entry(
 def _async_migrate_intelligent_unique_ids(
     entity_entry: er.RegistryEntry,
 ) -> dict[str, str] | None:
-    """Prefix legacy Intelligent unique_ids with the domain for consistency.
-
-    Older versions registered Octopus Intelligent entities as ``{device_id}_...``
-    without the ``octopus_french_`` prefix used by every other entity. All
-    non-Intelligent unique_ids already start with ``f"{DOMAIN}_"``, so prefixing
-    the ones that don't targets exactly the legacy Intelligent entities and
-    preserves their history and customisations.
-    """
+    """Prefix legacy Intelligent unique_ids with the domain for consistency."""
     if not entity_entry.unique_id.startswith(f"{DOMAIN}_"):
         return {"new_unique_id": f"{DOMAIN}_{entity_entry.unique_id}"}
     return None
@@ -210,8 +203,7 @@ async def _async_setup_intelligent_coordinator(
             return None
         return coordinator
     except ConfigEntryAuthFailed:
-        # Une erreur d'authentification n'est jamais « Intelligent indisponible » :
-        # elle doit déclencher le flow de réauthentification.
+        # Une erreur d'authentification doit déclencher le flow de réauthentification.
         raise
     except Exception as err:
         _LOGGER.debug("Octopus Intelligent not available for this account: %s", err)

--- a/custom_components/octopus_french/binary_sensor.py
+++ b/custom_components/octopus_french/binary_sensor.py
@@ -147,7 +147,7 @@ class OctopusFrenchHcBinarySensor(
         }
 
     @property
-    def available(self) -> bool:  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+    def available(self) -> bool:
         """Return True if entity is available."""
         return (
             self.coordinator.last_update_success

--- a/custom_components/octopus_french/coordinator.py
+++ b/custom_components/octopus_french/coordinator.py
@@ -43,7 +43,6 @@ class OctopusFrenchDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self.api_client = api_client
         self.account_number = account_number
-        # Renseigné au setup ; les sensors y lisent last_imported_date.
         self.statistics_importer: OctopusStatisticsImporter | None = None
 
     async def _async_update_data(self) -> dict[str, Any]:
@@ -81,8 +80,18 @@ class OctopusFrenchDataUpdateCoordinator(DataUpdateCoordinator):
         electricity_meter_ids = [
             sp.get("prm") for sp in electricity_supply_points if sp.get("prm")
         ]
+        # Chaque compteur peut vivre sur une property (logement) distincte : on
+        # route chaque PRM vers SA property, sinon les relevés du 2e compteur
+        # seraient demandés sur la property du 1er (issue #56).
+        property_id_by_prm = {
+            sp["prm"]: sp.get("property_id") or account_id
+            for sp in electricity_supply_points
+            if sp.get("prm")
+        }
         gas_supply_points = supply_points.get("gas", [])
-        gas_meter_id = gas_supply_points[0].get("prm") if gas_supply_points else None
+        gas_meter = gas_supply_points[0] if gas_supply_points else None
+        gas_meter_id = gas_meter.get("prm") if gas_meter else None
+        gas_property_id = (gas_meter.get("property_id") or account_id) if gas_meter else None
 
         now = dt_util.now()
         today_midnight = dt_util.start_of_local_day(now)
@@ -96,7 +105,7 @@ class OctopusFrenchDataUpdateCoordinator(DataUpdateCoordinator):
         async def fetch_electricity_for_prm(prm_id: str) -> tuple[str, list, Any]:
             try:
                 readings = await self.api_client.get_energy_readings(
-                    account_id,
+                    property_id_by_prm.get(prm_id, account_id),
                     electricity_start,
                     date_end,
                     prm_id,
@@ -121,7 +130,7 @@ class OctopusFrenchDataUpdateCoordinator(DataUpdateCoordinator):
                 return []
             try:
                 return await self.api_client.get_energy_readings(
-                    account_id,
+                    gas_property_id or account_id,
                     gas_start,
                     date_end,
                     gas_meter_id,

--- a/custom_components/octopus_french/coordinator.py
+++ b/custom_components/octopus_french/coordinator.py
@@ -91,7 +91,9 @@ class OctopusFrenchDataUpdateCoordinator(DataUpdateCoordinator):
         gas_supply_points = supply_points.get("gas", [])
         gas_meter = gas_supply_points[0] if gas_supply_points else None
         gas_meter_id = gas_meter.get("prm") if gas_meter else None
-        gas_property_id = (gas_meter.get("property_id") or account_id) if gas_meter else None
+        gas_property_id = (
+            (gas_meter.get("property_id") or account_id) if gas_meter else None
+        )
 
         now = dt_util.now()
         today_midnight = dt_util.start_of_local_day(now)

--- a/custom_components/octopus_french/manifest.json
+++ b/custom_components/octopus_french/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/domodom30/ha-octopus-french/issues",
   "requirements": ["PyJWT>=2.10.1"],
-  "version": "4.0.0"
+  "version": "4.0.1"
 }

--- a/custom_components/octopus_french/octopus_french.py
+++ b/custom_components/octopus_french/octopus_french.py
@@ -420,8 +420,6 @@ class OctopusFrenchApiClient:
         self._session = session
         self.token_manager = TokenManager()
         self._auth_lock = asyncio.Lock()
-        # Notifié à chaque rotation du refresh token (None = token invalidé),
-        # pour que l'appelant puisse le persister entre les redémarrages.
         self.on_token_update: Callable[[str | None, float | None], None] | None = None
 
     async def _async_execute(
@@ -748,6 +746,7 @@ class OctopusFrenchApiClient:
 
                 meter_point["prm"] = node.get("externalIdentifier")
                 meter_point["supply_point_id"] = node.get("id")
+                meter_point["property_id"] = prop.get("id")
                 meter_point["market_name"] = node.get("marketName")
 
                 if "meterKind" in meter_point or "distributorStatus" in meter_point:

--- a/custom_components/octopus_french/select.py
+++ b/custom_components/octopus_french/select.py
@@ -41,7 +41,7 @@ async def async_setup_entry(
         async_add_entities(entities)
 
 
-class OctopusIntelligentTargetTimeSelect(  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+class OctopusIntelligentTargetTimeSelect(
     CoordinatorEntity[OctopusIntelligentDataUpdateCoordinator], SelectEntity
 ):
     """Select entity for target charging time (30-minute intervals)."""

--- a/custom_components/octopus_french/sensor.py
+++ b/custom_components/octopus_french/sensor.py
@@ -238,7 +238,7 @@ def _detect_tariff_type_for_meter(data: dict, prm_id: str) -> str:
     return "UNKNOWN"
 
 
-class OctopusIntelligentVehicleStatusSensor(  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+class OctopusIntelligentVehicleStatusSensor(
     CoordinatorEntity[OctopusIntelligentDataUpdateCoordinator], SensorEntity
 ):
     """Sensor for vehicle charging status."""
@@ -284,7 +284,7 @@ class OctopusIntelligentVehicleStatusSensor(  # pyright: ignore[reportIncompatib
         }
 
 
-class OctopusIntelligentWeekdayTargetSocSensor(  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+class OctopusIntelligentWeekdayTargetSocSensor(
     CoordinatorEntity[OctopusIntelligentDataUpdateCoordinator], SensorEntity
 ):
     """Sensor for weekday target state of charge."""
@@ -325,7 +325,7 @@ class OctopusIntelligentWeekdayTargetSocSensor(  # pyright: ignore[reportIncompa
         )
 
 
-class OctopusIntelligentWeekdayTargetTimeSensor(  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+class OctopusIntelligentWeekdayTargetTimeSensor(
     CoordinatorEntity[OctopusIntelligentDataUpdateCoordinator], SensorEntity
 ):
     """Sensor for weekday target charging time."""
@@ -364,7 +364,7 @@ class OctopusIntelligentWeekdayTargetTimeSensor(  # pyright: ignore[reportIncomp
         )
 
 
-class OctopusIntelligentWeekendTargetSocSensor(  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+class OctopusIntelligentWeekendTargetSocSensor(
     CoordinatorEntity[OctopusIntelligentDataUpdateCoordinator], SensorEntity
 ):
     """Sensor for weekend target state of charge."""
@@ -405,7 +405,7 @@ class OctopusIntelligentWeekendTargetSocSensor(  # pyright: ignore[reportIncompa
         )
 
 
-class OctopusIntelligentWeekendTargetTimeSensor(  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+class OctopusIntelligentWeekendTargetTimeSensor(
     CoordinatorEntity[OctopusIntelligentDataUpdateCoordinator], SensorEntity
 ):
     """Sensor for weekend target charging time."""
@@ -444,7 +444,7 @@ class OctopusIntelligentWeekendTargetTimeSensor(  # pyright: ignore[reportIncomp
         )
 
 
-class OctopusIntelligentPlannedDispatchesSensor(  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+class OctopusIntelligentPlannedDispatchesSensor(
     CoordinatorEntity[OctopusIntelligentDataUpdateCoordinator], SensorEntity
 ):
     """Sensor for planned charging dispatches."""

--- a/custom_components/octopus_french/sensors/electricity.py
+++ b/custom_components/octopus_french/sensors/electricity.py
@@ -31,7 +31,7 @@ from .descriptions import OctopusIndexSensorDescription
 _LOGGER = logging.getLogger(__name__)
 
 
-class OctopusElectricitySensor(  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+class OctopusElectricitySensor(
     CoordinatorEntity[OctopusFrenchDataUpdateCoordinator], SensorEntity
 ):
     """Sensor for electricity data with statistics support."""
@@ -434,7 +434,7 @@ class OctopusElectricitySensor(  # pyright: ignore[reportIncompatibleVariableOve
         return normalize_provider_calendar(meter)
 
 
-class OctopusLatestReadingSensor(  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+class OctopusLatestReadingSensor(
     CoordinatorEntity[OctopusFrenchDataUpdateCoordinator], SensorEntity
 ):
     """Sensor for the latest daily electricity reading."""
@@ -668,7 +668,7 @@ class OctopusElectricityIndexSensor(
         }
 
     @property
-    def available(self) -> bool:  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+    def available(self) -> bool:
         """Return if entity is available."""
         if not super().available:
             return False
@@ -746,7 +746,7 @@ class OctopusTempoColorSensor(
         }
 
     @property
-    def available(self) -> bool:  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+    def available(self) -> bool:
         """Return True only when coordinator data is fresh (and tomorrow's color is known)."""
         if not (
             self.coordinator.last_update_success and self.coordinator.data is not None
@@ -763,7 +763,7 @@ class OctopusTempoColorSensor(
         return True
 
 
-class OctopusTempoCurrentRateSensor(  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+class OctopusTempoCurrentRateSensor(
     CoordinatorEntity[OctopusFrenchDataUpdateCoordinator], SensorEntity
 ):
     """Capteur dynamique : tarif OctoTempo actif en ce moment (€/kWh)."""

--- a/custom_components/octopus_french/sensors/gas.py
+++ b/custom_components/octopus_french/sensors/gas.py
@@ -17,7 +17,7 @@ from ..utils import get_tariff_rate_for_key
 _LOGGER = logging.getLogger(__name__)
 
 
-class OctopusGasSensor(  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+class OctopusGasSensor(
     CoordinatorEntity[OctopusFrenchDataUpdateCoordinator], SensorEntity
 ):
     """Sensor for gas data."""

--- a/custom_components/octopus_french/sensors/ledger.py
+++ b/custom_components/octopus_french/sensors/ledger.py
@@ -15,7 +15,7 @@ from .descriptions import OctopusLedgerSensorDescription
 _LOGGER = logging.getLogger(__name__)
 
 
-class OctopusLedgerSensor(  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+class OctopusLedgerSensor(
     CoordinatorEntity[OctopusFrenchDataUpdateCoordinator], SensorEntity
 ):
     """Sensor for account ledgers (balances)."""

--- a/custom_components/octopus_french/statistics_import.py
+++ b/custom_components/octopus_french/statistics_import.py
@@ -1,18 +1,4 @@
-"""Import centralisé des statistiques long-terme (électricité + gaz).
-
-Une seule passe sur les readings du coordinator calcule les valeurs journalières
-de toutes les clés (energy_*, cost_*, consumption, cost), puis chaque
-``statistic_id`` est importé avec l'algorithme historique :
-
-- fusion des offsets UTC mixtes sur le même jour local ;
-- fenêtre contiguë → réécriture depuis une ancre (répare les sommes corrompues) ;
-- fenêtre trouée → append-only après le dernier jour déjà importé ;
-- garde de ré-entrance.
-
-Les ``statistic_id`` (``octopus_french:{prm}_{key}``) et les noms de metadata
-sont identiques à ceux écrits par les entités jusqu'à la v3.4.0 : aucune
-migration de données.
-"""
+"""Import centralisé des statistiques long-terme (électricité + gaz)."""
 
 from __future__ import annotations
 
@@ -90,8 +76,6 @@ class OctopusStatisticsImporter:
         finally:
             self._import_in_progress = False
 
-    # ------------------------------------------------------------------ collect
-
     def _collect_electricity_daily_values(
         self, data: dict[str, Any], prm_id: str, readings: list[dict[str, Any]]
     ) -> dict[str, dict[datetime, float]]:
@@ -136,12 +120,8 @@ class OctopusStatisticsImporter:
         stat: dict[str, Any],
         rates: dict[str, float | None],
     ) -> float | None:
-        """Coût d'un relevé : montant réel de l'API, sinon kWh x tarif actuel.
+        """Coût d'un relevé : montant réel de l'API, sinon kWh x tarif actuel."""
 
-        ``costInclTax.estimatedAmount`` (en centimes) reflète le tarif en vigueur
-        au moment du relevé — contrairement au fallback, faux après un
-        changement de prix.
-        """
         amount = (stat.get("costInclTax") or {}).get("estimatedAmount")
         if amount is not None:
             try:
@@ -156,8 +136,6 @@ class OctopusStatisticsImporter:
             rates[cost_key] = get_tariff_rate_for_key(data, prm_id, cost_key)
         rate = rates[cost_key]
         return float(value) * rate if rate else None
-
-    # ------------------------------------------------------------------- passes
 
     async def _async_import_electricity(self) -> None:
         """Import electricity statistics for every PRM."""
@@ -231,8 +209,6 @@ class OctopusStatisticsImporter:
             unit=CURRENCY_EURO,
             daily_values=cost_values,
         )
-
-    # ------------------------------------------------------------------- import
 
     async def _async_import_statistic(
         self,

--- a/custom_components/octopus_french/switch.py
+++ b/custom_components/octopus_french/switch.py
@@ -40,7 +40,7 @@ async def async_setup_entry(
         async_add_entities(entities)
 
 
-class OctopusIntelligentBumpChargeSwitch(  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+class OctopusIntelligentBumpChargeSwitch(
     CoordinatorEntity[OctopusIntelligentDataUpdateCoordinator], SwitchEntity
 ):
     """Switch for boost charge."""
@@ -90,8 +90,6 @@ class OctopusIntelligentBumpChargeSwitch(  # pyright: ignore[reportIncompatibleV
             self._device_id
         )
         self.coordinator.data["boost_refusal_reasons"] = refusal_reasons
-        # Notifie les listeners même en cas de refus (sinon l'attribut
-        # refusal_reasons resterait figé jusqu'au prochain refresh).
         self.coordinator.async_set_updated_data(self.coordinator.data)
         if refusal_reasons and refusal_reasons != ["BC_BOOST_CHARGE_IN_PROGRESS"]:
             raise HomeAssistantError(

--- a/custom_components/octopus_french/utils.py
+++ b/custom_components/octopus_french/utils.py
@@ -69,15 +69,8 @@ def parse_off_peak_hours(off_peak_label: str | None) -> dict[str, Any]:
 
 
 def parse_time_slots(time_slots: list[dict[str, Any]]) -> dict[str, Any]:
-    """
-    Convert structured timeSlots from the contract API to the HC schedule format.
+    """Convert structured timeSlots from the contract API to the HC schedule format."""
 
-    Produces the same dict shape as parse_off_peak_hours() so the two sources
-    are interchangeable downstream.  The 'source' key distinguishes them.
-
-    time_slots items are expected to have 'start' and 'end' in HH:MM:SS format,
-    as returned by _extract_tariffs() after mapping startAt/endAt.
-    """
     result: dict[str, Any] = {
         "type": "HC",
         "ranges": [],
@@ -131,11 +124,7 @@ def parse_time_slots(time_slots: list[dict[str, Any]]) -> dict[str, Any]:
 def find_contract_hc_slots(
     data: dict[str, Any], prm_id: str
 ) -> list[dict[str, Any]] | None:
-    """
-    Return the HC timeSlots from the active contract for a given PRM, or None.
-
-    Checks heures_creuses first (HP/HC contract), then any *_hc key (Tempo).
-    """
+    """Return the HC timeSlots from the active contract for a given PRM, or None."""
     for agreement in data.get("agreements", []):
         if agreement.get("prm") != prm_id or not agreement.get("is_active"):
             continue
@@ -193,7 +182,6 @@ def normalize_provider_calendar(meter: dict) -> str:
     if len(codes) == 1:
         return "BASE"
 
-    # Repli : le meter n'expose pas de classes temporelles exploitables.
     calendar_id = (meter.get("providerCalendar") or {}).get("id", "") or ""
     upper = calendar_id.upper()
     if any(kw in upper for kw in TEMPO_PRODUCT_CODE_KEYWORDS):
@@ -202,13 +190,13 @@ def normalize_provider_calendar(meter: dict) -> str:
         return "HPHC"
     if "BASE" in upper:
         return "BASE"
-    return calendar_id  # inconnu → ne rien perdre
+    return calendar_id
 
 
 _RATE_KEY_TO_CONSUMPTION_KEY: dict[str, str] = {
     "rate_base": "base",
     "cost_base": "base",
-    "cost": "base",  # coût gaz (tarif base uniquement)
+    "cost": "base",
     "rate_peak_hours": "heures_pleines",
     "cost_peak_hours": "heures_pleines",
     "rate_off_peak_hours": "heures_creuses",
@@ -231,12 +219,8 @@ _RATE_KEY_TO_CONSUMPTION_KEY: dict[str, str] = {
 def get_tariff_rate_for_key(
     data: dict[str, Any], prm_id: str, key: str
 ) -> float | None:
-    """
-    Retourne le prix TTC (€/kWh) du contrat actif pour une clé de sensor.
+    """Retourne le prix TTC (€/kWh) du contrat actif pour une clé de sensor."""
 
-    Partagé entre les sensors (rate_*, coût mensuel) et l'import de statistiques
-    (fallback quand l'API ne fournit pas costInclTax).
-    """
     consumption_key = _RATE_KEY_TO_CONSUMPTION_KEY.get(key)
     if not consumption_key:
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ha-octopus-french"
 version = "4.0.0"
 description = "Octopus French custom integration for Home Assistant"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.14"
 license = { text = "MIT" }
 authors = [
     { name = "Domodom30" }
@@ -18,6 +18,8 @@ authors = [
 ###############################################################################
 
 [tool.ruff]
+# Runtime = Python 3.14, mais on garde py313 comme cible de syntaxe pour ne pas
+# adopter la syntaxe PEP 758 (`except A, B:` sans parenthèses), peu lisible.
 target-version = "py313"
 line-length = 88
 
@@ -46,7 +48,7 @@ quote-style = "double"
 ###############################################################################
 
 [tool.pyright]
-pythonVersion = "3.13"
+pythonVersion = "3.14"
 # basic : le code livré passe proprement (imports/appels/attributs/types restent des erreurs).
 # strict ajoutait ~700 remontées "type inconnu" sans valeur ici (HA partiellement typé + mocks).
 typeCheckingMode = "basic"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,8 @@
 #
 # pytest-homeassistant-custom-component épingle exactement homeassistant et pytest.
 # La version ci-dessous correspond à Home Assistant 2026.3.2 (schéma 0.13.PATCH).
+# NB : Home Assistant >= 2026.3 exige Python >= 3.14.2 (les tests ne tournent donc
+# plus sous Python 3.13).
 # Pour la mettre à jour, aligner sur la version de HA visée puis :
 #   pip install pytest-homeassistant-custom-component -c <(echo "homeassistant==<version>")
 #

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -75,6 +75,91 @@ async def test_electricity_scoped_per_prm() -> None:
     assert by_prm["PRM_B"]["index"]["prm"] == "PRM_B"
 
 
+async def test_electricity_readings_use_own_property_id() -> None:
+    """Chaque PRM interroge SA property, pas celle du premier logement (issue #56).
+
+    Deux compteurs sur deux logements (properties) distincts : les relevés du
+    second ne doivent pas être demandés sur la property du premier.
+    """
+    account_data = {
+        "account_id": "PROP-1",
+        "account_number": "ACC-123",
+        "supply_points": {
+            "electricity": [
+                {
+                    "prm": "PRM_A",
+                    "distributorStatus": "SERVC",
+                    "property_id": "PROP-1",
+                },
+                {
+                    "prm": "PRM_B",
+                    "distributorStatus": "SERVC",
+                    "property_id": "PROP-2",
+                },
+            ],
+            "gas": [],
+        },
+        "agreements": [],
+        "ledgers": {},
+    }
+
+    coordinator = _make_coordinator(account_data)
+
+    property_by_prm: dict[str, str] = {}
+
+    async def _readings(
+        property_id: str,
+        start: str,
+        end: str,
+        prm_id: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        property_by_prm[prm_id] = property_id
+        return [{"prm": prm_id}]
+
+    coordinator.api_client.get_energy_readings.side_effect = _readings
+
+    await coordinator._fetch_all_data()
+
+    assert property_by_prm == {"PRM_A": "PROP-1", "PRM_B": "PROP-2"}
+
+
+async def test_electricity_property_id_falls_back_to_account_id() -> None:
+    """Sans property_id sur le compteur, on retombe sur account_id (compat)."""
+    account_data = {
+        "account_id": "PROP-1",
+        "account_number": "ACC-123",
+        "supply_points": {
+            "electricity": [
+                {"prm": "PRM_A", "distributorStatus": "SERVC"},
+            ],
+            "gas": [],
+        },
+        "agreements": [],
+        "ledgers": {},
+    }
+
+    coordinator = _make_coordinator(account_data)
+
+    seen: dict[str, str] = {}
+
+    async def _readings(
+        property_id: str,
+        start: str,
+        end: str,
+        prm_id: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        seen[prm_id] = property_id
+        return []
+
+    coordinator.api_client.get_energy_readings.side_effect = _readings
+
+    await coordinator._fetch_all_data()
+
+    assert seen == {"PRM_A": "PROP-1"}
+
+
 async def test_resiliated_supply_point_is_filtered_out() -> None:
     """Un point de livraison résilié (RESIL) est exclu du fetch."""
     account_data = {

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -84,6 +84,35 @@ def test_extract_supply_points_with_null_provider_calendar(
     assert meter["provider_temporal_classes"] == []
 
 
+def test_extract_supply_points_keeps_parent_property_id(
+    client: OctopusFrenchApiClient,
+) -> None:
+    """Chaque compteur retient l'id de SA property (routage des relevés, issue #56)."""
+    properties = [
+        {
+            "id": "PROP-1",
+            "supplyPoints": {
+                "edges": [
+                    {"node": {"externalIdentifier": "PRM_A", "meterPoint": {"meterKind": "SMART"}}}
+                ]
+            },
+        },
+        {
+            "id": "PROP-2",
+            "supplyPoints": {
+                "edges": [
+                    {"node": {"externalIdentifier": "PRM_B", "meterPoint": {"meterKind": "SMART"}}}
+                ]
+            },
+        },
+    ]
+
+    electricity = client._extract_supply_points(properties)["electricity"]
+    property_by_prm = {m["prm"]: m["property_id"] for m in electricity}
+
+    assert property_by_prm == {"PRM_A": "PROP-1", "PRM_B": "PROP-2"}
+
+
 def test_extract_agreements_with_null_nested_objects(
     client: OctopusFrenchApiClient,
 ) -> None:

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -93,7 +93,12 @@ def test_extract_supply_points_keeps_parent_property_id(
             "id": "PROP-1",
             "supplyPoints": {
                 "edges": [
-                    {"node": {"externalIdentifier": "PRM_A", "meterPoint": {"meterKind": "SMART"}}}
+                    {
+                        "node": {
+                            "externalIdentifier": "PRM_A",
+                            "meterPoint": {"meterKind": "SMART"},
+                        }
+                    }
                 ]
             },
         },
@@ -101,7 +106,12 @@ def test_extract_supply_points_keeps_parent_property_id(
             "id": "PROP-2",
             "supplyPoints": {
                 "edges": [
-                    {"node": {"externalIdentifier": "PRM_B", "meterPoint": {"meterKind": "SMART"}}}
+                    {
+                        "node": {
+                            "externalIdentifier": "PRM_B",
+                            "meterPoint": {"meterKind": "SMART"},
+                        }
+                    }
                 ]
             },
         },


### PR DESCRIPTION
## Résumé

Publication de la version **4.0.1**.

### 🐛 Corrections
- **Comptes multi-Linky (issue #56)** : sur un compte à plusieurs contrats/logements, les relevés de consommation sont désormais récupérés sur la bonne propriété pour chaque point de livraison. Les données ne sont plus mélangées ni dupliquées entre les deux compteurs.

### 🧹 Interne
- Nettoyage de commentaires/docstrings sur plusieurs modules.
- Bump `manifest.json` 4.0.0 → 4.0.1, entrée CHANGELOG.

### ✅ Vérification
- `pytest tests/` → 177 passed
- `ruff check` → clean