### PR TITLE
fix: types GraphQL setDevicePreferences ID!/Time!/Decimal! (issue #55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 🐛 Corrections
 
 - **Comptes multi-Linky (issue #56)** : sur un compte à plusieurs contrats/logements, les relevés de consommation sont désormais récupérés sur la **bonne propriété** pour chaque point de livraison. Les données ne sont plus mélangées ni dupliquées entre les deux compteurs.
+- **Recharge Intelligent / charge cible (issue #55)** : la mutation `setDevicePreferences` déclarait des types GraphQL erronés (`String!`/`Int!`), rejetés par l'API (HTTP 400) et masqués en « endpoint injoignable ». Les types corrects (`ID!`/`Time!`/`Decimal!`) sont désormais utilisés — la charge cible, l'heure cible et la recharge rapide refonctionnent.
 
 ---
 

--- a/custom_components/octopus_french/api/intelligent.py
+++ b/custom_components/octopus_french/api/intelligent.py
@@ -61,7 +61,7 @@ query flexPlannedDispatches($deviceId: String!) {
 # Les 7 jours sont écrits en littéral : ce sont des enums GraphQL (pas des valeurs
 # interpolées). Seuls time/max varient et passent par des variables réutilisées.
 MUTATION_SET_DEVICE_PREFERENCES = """
-mutation setDevicePreferences($deviceId: String!, $time: String!, $max: Int!) {
+mutation setDevicePreferences($deviceId: ID!, $time: Time!, $max: Decimal!) {
   setDevicePreferences(input: {
     deviceId: $deviceId
     mode: CHARGE

--- a/tests/test_device_preferences.py
+++ b/tests/test_device_preferences.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.octopus_french.api.intelligent import (
+    MUTATION_SET_DEVICE_PREFERENCES,
     OctopusIntelligentApiClient,
 )
 from custom_components.octopus_french.coordinator_intelligent import (
@@ -28,6 +29,17 @@ _DAYS_OF_WEEK = [
     "SATURDAY",
     "SUNDAY",
 ]
+
+
+def test_set_device_preferences_declares_correct_graphql_types():
+    """setDevicePreferences doit déclarer deviceId/time/max en ID!/Time!/Decimal! (issue #55).
+
+    Kraken rejette `String!`/`Int!` en HTTP 400 (« used in position expecting type 'ID!' »),
+    ce qui cassait la charge cible / l'heure cible / la recharge rapide.
+    """
+    assert "$deviceId: ID!" in MUTATION_SET_DEVICE_PREFERENCES
+    assert "$time: Time!" in MUTATION_SET_DEVICE_PREFERENCES
+    assert "$max: Decimal!" in MUTATION_SET_DEVICE_PREFERENCES
 
 
 @pytest.fixture


### PR DESCRIPTION
## Contexte

Corrige **#55** (« Charge cible ne fonctionne plus »).

La mutation `setDevicePreferences` déclarait de mauvais types GraphQL (`$deviceId: String!, $time: String!, $max: Int!`). Depuis que Kraken a durci sa validation, ils sont rejetés en **HTTP 400** (`Variable '$deviceId' of type 'String!' used in position expecting type 'ID!'`), erreur masquée en « Unable to reach GraphQL endpoint » par le wrapper de retry.

Diagnostic initial du contributeur @Mathieu-Pasco-Breillot (issue #55 / PR #58).

## Changement

- `api/intelligent.py` : types corrigés en `ID!` / `Time!` / `Decimal!` (les variables Python passées sont inchangées).
- Test de garde sur les types déclarés.
- Entrée CHANGELOG 4.0.1.

## Vérification
- `pytest tests/` → 178 passed
- `ruff check` + `ruff format --check .` → clean