### PR TITLE
feat: interrupteur Smart Control (suspend/restore) — Octopus Intelligent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.1.0] - 2026-07-23
+
+### ✨ Nouveautés
+
+- **Interrupteur « Contrôle intelligent » (Octopus Intelligent)** : un nouveau switch par véhicule permet de **suspendre ou rétablir le pilotage automatique Octopus**. Contrairement au boost, suspendre le contrôle intelligent n'entraîne pas de coût — cela empêche simplement Octopus d'interrompre une session de charge qu'il n'a pas planifiée.
+
+---
+
 ## [4.0.1] - 2026-07-23
 
 ### 🐛 Corrections

--- a/custom_components/octopus_french/api/intelligent.py
+++ b/custom_components/octopus_french/api/intelligent.py
@@ -33,6 +33,19 @@ query devices($accountNumber: String!) {
     status {
       current
       currentState
+      isSuspended
+    }
+  }
+}
+"""
+
+MUTATION_UPDATE_DEVICE_SMART_CONTROL = """
+mutation updateDeviceSmartControl($deviceId: ID!, $action: SmartControlAction!) {
+  updateDeviceSmartControl(input: { deviceId: $deviceId, action: $action }) {
+    id
+    name
+    status {
+      isSuspended
     }
   }
 }
@@ -122,6 +135,24 @@ class OctopusIntelligentApiClient:
     ) -> tuple[dict[str, Any] | None, list[str]]:
         """Cancel boost charge. Returns (data, refusal_reasons)."""
         return await self._update_boost_charge(device_id, MUTATION_CANCEL_BOOST_CHARGE)
+
+    async def _update_smart_control(self, device_id: str, action: str) -> bool:
+        """Suspend or unsuspend Octopus's automatic smart control of a device."""
+        response = await self.api_client.execute_with_auth(
+            MUTATION_UPDATE_DEVICE_SMART_CONTROL,
+            {"deviceId": device_id, "action": action},
+        )
+        if response and "errors" in response:
+            return False
+        return response is not None and "data" in response
+
+    async def suspend_smart_control(self, device_id: str) -> bool:
+        """Suspend Octopus's automatic smart control (stops it interrupting charging)."""
+        return await self._update_smart_control(device_id, "SUSPEND")
+
+    async def unsuspend_smart_control(self, device_id: str) -> bool:
+        """Restore Octopus's automatic smart control."""
+        return await self._update_smart_control(device_id, "UNSUSPEND")
 
     async def get_devices(self, account_number: str) -> list[dict[str, Any]]:
         """Get list of Intelligent devices for an account."""

--- a/custom_components/octopus_french/manifest.json
+++ b/custom_components/octopus_french/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/domodom30/ha-octopus-french/issues",
   "requirements": ["PyJWT>=2.10.1"],
-  "version": "4.0.1"
+  "version": "4.1.0"
 }

--- a/custom_components/octopus_french/strings.json
+++ b/custom_components/octopus_french/strings.json
@@ -1005,6 +1005,9 @@
             "name": "Refusal reasons"
           }
         }
+      },
+      "smart_control": {
+        "name": "Smart control"
       }
     },
     "number": {
@@ -1036,6 +1039,9 @@
     },
     "cancel_boost_charge_failed": {
       "message": "Failed to cancel boost charge: {reasons}."
+    },
+    "update_smart_control_failed": {
+      "message": "Failed to update smart control for device {device_id}."
     }
   }
 }

--- a/custom_components/octopus_french/switch.py
+++ b/custom_components/octopus_french/switch.py
@@ -5,6 +5,7 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -26,15 +27,18 @@ async def async_setup_entry(
     if coordinator is None:
         return
 
-    entities = [
-        OctopusIntelligentBumpChargeSwitch(
-            coordinator,
-            device["id"],
-            device.get("name", "Véhicule"),
+    entities: list[SwitchEntity] = []
+    for device in coordinator.data.get("devices", []):
+        device_id = device.get("id")
+        if not device_id:
+            continue
+        device_name = device.get("name", "Véhicule")
+        entities.append(
+            OctopusIntelligentBumpChargeSwitch(coordinator, device_id, device_name)
         )
-        for device in coordinator.data.get("devices", [])
-        if device.get("id")
-    ]
+        entities.append(
+            OctopusIntelligentSmartControlSwitch(coordinator, device_id, device_name)
+        )
 
     if entities:
         async_add_entities(entities)
@@ -114,5 +118,72 @@ class OctopusIntelligentBumpChargeSwitch(
                 translation_domain=DOMAIN,
                 translation_key="cancel_boost_charge_failed",
                 translation_placeholders={"reasons": ", ".join(refusal_reasons)},
+            )
+        await self.coordinator.async_refresh_devices()
+
+
+class OctopusIntelligentSmartControlSwitch(
+    CoordinatorEntity[OctopusIntelligentDataUpdateCoordinator], SwitchEntity
+):
+    """Switch to suspend/restore Octopus's automatic smart control of a device.
+
+    Unlike boost charge, suspending smart control does not incur the
+    Intelligent tariff's boost-usage cost. It stops Octopus from
+    interrupting a charging session it did not schedule itself, at the
+    cost of losing Octopus's own schedule optimisation while suspended.
+    """
+
+    def __init__(
+        self,
+        coordinator: OctopusIntelligentDataUpdateCoordinator,
+        device_id: str,
+        device_name: str,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._attr_unique_id = f"{DOMAIN}_{device_id}_smart_control"
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "smart_control"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_id)},
+            via_device=(DOMAIN, coordinator.account_number),
+            name=device_name,
+            model=device_name,
+        )
+
+    def _get_device_status(self) -> dict[str, Any]:
+        """Return the device payload from coordinator data."""
+        return self.coordinator.get_device(self._device_id) or {}
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if Octopus's automatic smart control is active (not suspended)."""
+        status_data = self._get_device_status().get("status", {})
+        return not status_data.get("isSuspended", False)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Restore Octopus's automatic smart control."""
+        success = await self.coordinator.intelligent_client.unsuspend_smart_control(
+            self._device_id
+        )
+        if not success:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="update_smart_control_failed",
+                translation_placeholders={"device_id": self._device_id},
+            )
+        await self.coordinator.async_refresh_devices()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Suspend Octopus's automatic smart control."""
+        success = await self.coordinator.intelligent_client.suspend_smart_control(
+            self._device_id
+        )
+        if not success:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="update_smart_control_failed",
+                translation_placeholders={"device_id": self._device_id},
             )
         await self.coordinator.async_refresh_devices()

--- a/custom_components/octopus_french/translations/en.json
+++ b/custom_components/octopus_french/translations/en.json
@@ -1005,6 +1005,9 @@
             "name": "Refusal reasons"
           }
         }
+      },
+      "smart_control": {
+        "name": "Smart control"
       }
     },
     "number": {
@@ -1036,6 +1039,9 @@
     },
     "cancel_boost_charge_failed": {
       "message": "Failed to cancel boost charge: {reasons}."
+    },
+    "update_smart_control_failed": {
+      "message": "Failed to update smart control for device {device_id}."
     }
   }
 }

--- a/custom_components/octopus_french/translations/fr.json
+++ b/custom_components/octopus_french/translations/fr.json
@@ -1005,6 +1005,9 @@
             "name": "Raisons de refus"
           }
         }
+      },
+      "smart_control": {
+        "name": "Contrôle intelligent"
       }
     },
     "number": {
@@ -1036,6 +1039,9 @@
     },
     "cancel_boost_charge_failed": {
       "message": "Impossible d'annuler la charge boost : {reasons}."
+    },
+    "update_smart_control_failed": {
+      "message": "Impossible de mettre à jour le contrôle intelligent pour l'appareil {device_id}."
     }
   }
 }

--- a/tests/test_api_intelligent.py
+++ b/tests/test_api_intelligent.py
@@ -4,7 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.octopus_french.api.intelligent import OctopusIntelligentApiClient
+from custom_components.octopus_french.api.intelligent import (
+    QUERY_DEVICES,
+    OctopusIntelligentApiClient,
+)
 
 
 @pytest.fixture
@@ -174,3 +177,55 @@ async def test_get_flex_planned_dispatches(intelligent_client, mock_api_client):
         {"start": "2026-04-22T21:00:00+00:00", "end": "2026-04-22T22:00:00+00:00"}
     ]
     mock_api_client.execute_with_auth.assert_called_once()
+
+
+def test_query_devices_requests_is_suspended():
+    """QUERY_DEVICES doit demander isSuspended (état du Smart Control switch)."""
+    assert "isSuspended" in QUERY_DEVICES
+
+
+@pytest.mark.asyncio
+async def test_suspend_smart_control_success(intelligent_client, mock_api_client):
+    """Suspend renvoie True et envoie l'action SUSPEND."""
+    mock_api_client.execute_with_auth.return_value = {
+        "data": {"updateDeviceSmartControl": {"id": "abc-123", "name": "Tesla"}}
+    }
+
+    result = await intelligent_client.suspend_smart_control("abc-123")
+
+    assert result is True
+    _, variables = mock_api_client.execute_with_auth.call_args[0]
+    assert variables == {"deviceId": "abc-123", "action": "SUSPEND"}
+
+
+@pytest.mark.asyncio
+async def test_unsuspend_smart_control_success(intelligent_client, mock_api_client):
+    """Unsuspend renvoie True et envoie l'action UNSUSPEND."""
+    mock_api_client.execute_with_auth.return_value = {
+        "data": {"updateDeviceSmartControl": {"id": "abc-123", "name": "Tesla"}}
+    }
+
+    result = await intelligent_client.unsuspend_smart_control("abc-123")
+
+    assert result is True
+    _, variables = mock_api_client.execute_with_auth.call_args[0]
+    assert variables == {"deviceId": "abc-123", "action": "UNSUSPEND"}
+
+
+@pytest.mark.asyncio
+async def test_update_smart_control_error(intelligent_client, mock_api_client):
+    """Une réponse en erreur renvoie False."""
+    mock_api_client.execute_with_auth.return_value = {
+        "errors": [{"message": "boom"}],
+        "data": None,
+    }
+
+    assert await intelligent_client.suspend_smart_control("abc-123") is False
+
+
+@pytest.mark.asyncio
+async def test_update_smart_control_empty_response(intelligent_client, mock_api_client):
+    """Une réponse vide renvoie False."""
+    mock_api_client.execute_with_auth.return_value = None
+
+    assert await intelligent_client.unsuspend_smart_control("abc-123") is False

--- a/tests/test_switch_smart_control.py
+++ b/tests/test_switch_smart_control.py
@@ -1,0 +1,114 @@
+"""Test the Smart Control suspend/restore switch."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.octopus_french.coordinator_intelligent import (
+    OctopusIntelligentDataUpdateCoordinator,
+)
+from custom_components.octopus_french.switch import (
+    OctopusIntelligentSmartControlSwitch,
+)
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Mock coordinator."""
+    coordinator = MagicMock(spec=OctopusIntelligentDataUpdateCoordinator)
+    coordinator.account_number = "A-XXXX"
+    coordinator.data = {
+        "devices": [
+            {
+                "id": "abc-123",
+                "name": "Tesla Model 3",
+                "status": {
+                    "current": "LIVE",
+                    "currentState": "SMART_CONTROL_CAPABLE",
+                    "isSuspended": False,
+                },
+            }
+        ],
+    }
+    coordinator.intelligent_client = MagicMock()
+    coordinator.intelligent_client.suspend_smart_control = AsyncMock(return_value=True)
+    coordinator.intelligent_client.unsuspend_smart_control = AsyncMock(
+        return_value=True
+    )
+    coordinator.async_refresh_devices = AsyncMock()
+    coordinator.get_device.side_effect = lambda device_id: next(
+        (d for d in coordinator.data["devices"] if d.get("id") == device_id),
+        None,
+    )
+    return coordinator
+
+
+@pytest.fixture
+def smart_control_switch(mock_coordinator):
+    """Create the smart control switch."""
+    return OctopusIntelligentSmartControlSwitch(
+        mock_coordinator,
+        "abc-123",
+        "Tesla Model 3",
+    )
+
+
+def test_unique_id_is_domain_prefixed(smart_control_switch):
+    """L'unique_id suit la convention DOMAIN_{device}_smart_control."""
+    assert smart_control_switch.unique_id == "octopus_french_abc-123_smart_control"
+
+
+def test_is_on_when_not_suspended(smart_control_switch):
+    """Smart control actif (non suspendu) → switch on."""
+    assert smart_control_switch.is_on is True
+
+
+def test_is_on_when_suspended(smart_control_switch, mock_coordinator):
+    """Smart control suspendu → switch off."""
+    mock_coordinator.data["devices"][0]["status"]["isSuspended"] = True
+    assert smart_control_switch.is_on is False
+
+
+@pytest.mark.asyncio
+async def test_turn_off_suspends(smart_control_switch, mock_coordinator):
+    """Éteindre le switch suspend le smart control."""
+    await smart_control_switch.async_turn_off()
+
+    mock_coordinator.intelligent_client.suspend_smart_control.assert_called_once_with(
+        "abc-123"
+    )
+    mock_coordinator.async_refresh_devices.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_turn_on_unsuspends(smart_control_switch, mock_coordinator):
+    """Allumer le switch rétablit le smart control."""
+    await smart_control_switch.async_turn_on()
+
+    mock_coordinator.intelligent_client.unsuspend_smart_control.assert_called_once_with(
+        "abc-123"
+    )
+    mock_coordinator.async_refresh_devices.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_turn_off_failure_raises(smart_control_switch, mock_coordinator):
+    """Un échec de suspension lève HomeAssistantError et ne rafraîchit pas."""
+    mock_coordinator.intelligent_client.suspend_smart_control.return_value = False
+
+    with pytest.raises(HomeAssistantError):
+        await smart_control_switch.async_turn_off()
+
+    mock_coordinator.async_refresh_devices.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_turn_on_failure_raises(smart_control_switch, mock_coordinator):
+    """Un échec de rétablissement lève HomeAssistantError et ne rafraîchit pas."""
+    mock_coordinator.intelligent_client.unsuspend_smart_control.return_value = False
+
+    with pytest.raises(HomeAssistantError):
+        await smart_control_switch.async_turn_on()
+
+    mock_coordinator.async_refresh_devices.assert_not_called()


### PR DESCRIPTION
## Contexte

Ajoute un interrupteur **Smart Control** (suspendre / rétablir le pilotage automatique Octopus d'un véhicule Intelligent).

Contrairement au boost charge, suspendre le smart control n'entraîne pas le coût d'un boost : cela empêche simplement Octopus d'interrompre une session de charge qu'il n'a pas planifiée.

Feature initialement proposée par @Mathieu-Pasco-Breillot dans la PR #58 (fermée sans merge), ici réintégrée **avec correction de convention** : l'`unique_id` est préfixé par `DOMAIN` (`octopus_french_{deviceId}_smart_control`), cohérent avec les autres entités Intelligent.

## Changements

- `api/intelligent.py` : mutation `updateDeviceSmartControl` + méthodes `suspend_smart_control` / `unsuspend_smart_control` ; `isSuspended` ajouté à `QUERY_DEVICES`.
- `switch.py` : entité `OctopusIntelligentSmartControlSwitch` (état `is_on = not isSuspended`, on/off → unsuspend/suspend, `HomeAssistantError` traduite en cas d'échec).
- Traductions `strings.json` / `en.json` / `fr.json` (nom du switch + message d'exception).
- Tests : `test_switch_smart_control.py` (nouveau) + extension de `test_api_intelligent.py`.

## Vérification
- `pytest tests/` → 190 passed
- `ruff check` + `ruff format --check .` → clean
- JSON de traduction validés

## À valider
Les identifiants d'API (`updateDeviceSmartControl`, enum `SmartControlAction`, `SUSPEND`/`UNSUSPEND`, `isSuspended`) proviennent du diagnostic de la PR #58 — à confirmer par un test terrain sur un compte Intelligent réel.