### PR TITLE
fix: attach boost switch to Intelligent vehicle device

### DIFF
--- a/custom_components/octopus_french/switch.py
+++ b/custom_components/octopus_french/switch.py
@@ -61,6 +61,12 @@ class OctopusIntelligentBumpChargeSwitch(
         self._attr_unique_id = f"{DOMAIN}_{device_id}_bump_charge"
         self._attr_has_entity_name = True
         self._attr_translation_key = "bump_charge"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_id)},
+            via_device=(DOMAIN, coordinator.account_number),
+            name=device_name,
+            model=device_name,
+        )
         self._update_attrs()
 
     def _get_device_status(self) -> dict[str, Any]:

--- a/tests/test_switch_bump_charge.py
+++ b/tests/test_switch_bump_charge.py
@@ -72,6 +72,16 @@ def bump_charge_switch(mock_coordinator):
     )
 
 
+def test_bump_charge_switch_is_attached_to_vehicle_device(bump_charge_switch):
+    """Test that the boost switch appears on the Intelligent vehicle device."""
+    assert bump_charge_switch.device_info == {
+        "identifiers": {("octopus_french", "abc-123")},
+        "via_device": ("octopus_french", "A-XXXX"),
+        "name": "Tesla Model 3",
+        "model": "Tesla Model 3",
+    }
+
+
 @pytest.mark.asyncio
 async def test_bump_charge_switch_on(bump_charge_switch, mock_coordinator):
     """Test turning on bump charge."""


### PR DESCRIPTION
Problème

Le switch de recharge boost est toujours créé, mais contrairement au switch de contrôle intelligent, il ne déclare aucun DeviceInfo.

Il n’est donc pas rattaché à l’appareil véhicule et n’apparaît plus dans sa fiche sous Appareils et services → Octopus.

Correctif

- Rattache OctopusIntelligentBumpChargeSwitch à l’appareil véhicule via ses identifiers.
- Conserve le lien vers l’appareil compte avec via_device.
- Ajoute un test de non-régression vérifiant le DeviceInfo.

Vérifications

- ruff check : OK
- ruff format : OK
- pyright : OK
- pytest : 191 tests réussis