### PR TITLE
Fix OctoTempo current HC period detection

### DIFF
--- a/custom_components/octopus_french/binary_sensor.py
+++ b/custom_components/octopus_french/binary_sensor.py
@@ -17,7 +17,12 @@ from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import OctopusFrenchDataUpdateCoordinator
-from .utils import find_contract_hc_slots, parse_off_peak_hours, parse_time_slots
+from .utils import (
+    find_contract_hc_slots,
+    get_tempo_color_for_prm,
+    parse_off_peak_hours,
+    parse_time_slots,
+)
 
 PARALLEL_UPDATES = 0
 
@@ -123,7 +128,8 @@ class OctopusFrenchHcBinarySensor(
         """
         data = self.coordinator.data or {}
 
-        if contract_slots := find_contract_hc_slots(data, self._prm_id):
+        tempo_color = get_tempo_color_for_prm(data, self._prm_id)
+        if contract_slots := find_contract_hc_slots(data, self._prm_id, tempo_color):
             schedule = parse_time_slots(contract_slots)
             if schedule["range_count"] > 0:
                 return schedule

--- a/custom_components/octopus_french/octopus_french.py
+++ b/custom_components/octopus_french/octopus_french.py
@@ -185,6 +185,11 @@ query getAccountData($accountNumber: String!, $activeAt: DateTime!) {
                   pricePerUnitWithTaxes
                   validFrom
                   validTo
+                  temporalClass {
+                    code
+                    label
+                    registerId
+                  }
                   timeSlots {
                     startAt
                     endAt

--- a/custom_components/octopus_french/sensors/electricity.py
+++ b/custom_components/octopus_french/sensors/electricity.py
@@ -21,6 +21,7 @@ from ..coordinator import OctopusFrenchDataUpdateCoordinator
 from ..utils import (
     find_contract_hc_slots,
     get_tariff_rate_for_key,
+    get_tempo_color_for_prm,
     normalize_consumption_label,
     normalize_provider_calendar,
     parse_off_peak_hours,
@@ -857,7 +858,8 @@ class OctopusTempoCurrentRateSensor(
     def _is_currently_hc(self) -> bool:
         """Return True if the current time falls within an HC (off-peak) period."""
         data = self.coordinator.data or {}
-        contract_slots = find_contract_hc_slots(data, self._prm_id)
+        tempo_color = get_tempo_color_for_prm(data, self._prm_id)
+        contract_slots = find_contract_hc_slots(data, self._prm_id, tempo_color)
         if contract_slots:
             schedule = parse_time_slots(contract_slots)
         else:

--- a/custom_components/octopus_french/utils.py
+++ b/custom_components/octopus_french/utils.py
@@ -13,6 +13,29 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+_TEMPO_COLOR_TO_HC_KEY = {
+    "ETE": "tempo_ete_hc",
+    "HIVER": "tempo_hiver_hc",
+    "ROUGE": "tempo_rouge_hc",
+}
+
+_OCTOFLEX_DEFAULT_HC_SLOTS = {
+    # OctoTempo exposes up to 16 off-peak hours in summer.
+    "ETE": [
+        {"start": "00:00:00", "end": "07:00:00"},
+        {"start": "11:00:00", "end": "20:00:00"},
+    ],
+    # Winter/red days expose 10 off-peak hours.
+    "HIVER": [
+        {"start": "00:00:00", "end": "07:00:00"},
+        {"start": "11:00:00", "end": "14:00:00"},
+    ],
+    "ROUGE": [
+        {"start": "00:00:00", "end": "07:00:00"},
+        {"start": "11:00:00", "end": "14:00:00"},
+    ],
+}
+
 
 def parse_off_peak_hours(off_peak_label: str | None) -> dict[str, Any]:
     """Parse off-peak hours label and extract time ranges."""
@@ -122,13 +145,22 @@ def parse_time_slots(time_slots: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def find_contract_hc_slots(
-    data: dict[str, Any], prm_id: str
+    data: dict[str, Any], prm_id: str, tempo_color: str | None = None
 ) -> list[dict[str, Any]] | None:
     """Return the HC timeSlots from the active contract for a given PRM, or None."""
     for agreement in data.get("agreements", []):
         if agreement.get("prm") != prm_id or not agreement.get("is_active"):
             continue
         consumption = (agreement.get("tariffs") or {}).get("consumption", {})
+
+        if tempo_color:
+            hc_key = _TEMPO_COLOR_TO_HC_KEY.get(tempo_color.upper())
+            if (
+                hc_key
+                and (rate := consumption.get(hc_key))
+                and (slots := rate.get("time_slots"))
+            ):
+                return slots
 
         hc_rate = consumption.get("heures_creuses") or {}
         if slots := hc_rate.get("time_slots"):
@@ -142,7 +174,20 @@ def find_contract_hc_slots(
             ):
                 return slots
 
+        product_code = ((agreement.get("product") or {}).get("code") or "").upper()
+        if any(kw in product_code for kw in TEMPO_PRODUCT_CODE_KEYWORDS):
+            color = (tempo_color or "").upper()
+            if slots := _OCTOFLEX_DEFAULT_HC_SLOTS.get(color):
+                return slots
+
     return None
+
+
+def get_tempo_color_for_prm(data: dict[str, Any], prm_id: str) -> str | None:
+    """Return the current Tempo color for a PRM from index data."""
+    index_data = data.get("electricity_by_prm", {}).get(prm_id, {}).get("index") or {}
+    color = index_data.get("tempo_color")
+    return color if isinstance(color, str) else None
 
 
 def normalize_consumption_label(label: str) -> str:

--- a/custom_components/octopus_french/utils.py
+++ b/custom_components/octopus_french/utils.py
@@ -20,20 +20,14 @@ _TEMPO_COLOR_TO_HC_KEY = {
 }
 
 _OCTOFLEX_DEFAULT_HC_SLOTS = {
-    # OctoTempo exposes up to 16 off-peak hours in summer.
+    # OctoTempo exposes 16 off-peak hours in summer: 21:00-07:00 and 11:00-17:00.
     "ETE": [
-        {"start": "00:00:00", "end": "07:00:00"},
-        {"start": "11:00:00", "end": "20:00:00"},
+        {"start": "21:00:00", "end": "07:00:00"},
+        {"start": "11:00:00", "end": "17:00:00"},
     ],
-    # Winter/red days expose 10 off-peak hours.
-    "HIVER": [
-        {"start": "00:00:00", "end": "07:00:00"},
-        {"start": "11:00:00", "end": "14:00:00"},
-    ],
-    "ROUGE": [
-        {"start": "00:00:00", "end": "07:00:00"},
-        {"start": "11:00:00", "end": "14:00:00"},
-    ],
+    # Winter/red days expose 10 off-peak hours: 21:00-07:00.
+    "HIVER": [{"start": "21:00:00", "end": "07:00:00"}],
+    "ROUGE": [{"start": "21:00:00", "end": "07:00:00"}],
 }
 
 

--- a/tests/test_hc_sensor.py
+++ b/tests/test_hc_sensor.py
@@ -146,6 +146,50 @@ class TestFindContractHcSlots:
         result = find_contract_hc_slots(data, "PRM1")
         assert result == slots
 
+    def test_octoflex_fallback_uses_tempo_color_schedule(self):
+        """OctoTempo ne doit pas retomber sur offPeakLabel si le contrat n'a pas de timeSlots."""
+        data = {
+            "agreements": [
+                {
+                    "prm": "PRM1",
+                    "is_active": True,
+                    "product": {"code": "OCTOFLEX_4"},
+                    "tariffs": {
+                        "consumption": {
+                            "tempo_ete_hp": {"price_ttc": 0.1575},
+                            "tempo_ete_hc": {"price_ttc": 0.1325},
+                        }
+                    },
+                }
+            ],
+            "supply_points": {
+                "electricity": [{"id": "PRM1", "offPeakLabel": "HC (22H00-6H00)"}]
+            },
+        }
+
+        slots = find_contract_hc_slots(data, "PRM1", tempo_color="ETE")
+        schedule = parse_time_slots(slots or [])
+
+        assert schedule["ranges"] == [
+            {
+                "start": "00:00",
+                "end": "07:00",
+                "start_minutes": 0,
+                "end_minutes": 420,
+                "duration_minutes": 420,
+                "duration_hours": 7.0,
+            },
+            {
+                "start": "11:00",
+                "end": "20:00",
+                "start_minutes": 660,
+                "end_minutes": 1200,
+                "duration_minutes": 540,
+                "duration_hours": 9.0,
+            },
+        ]
+        assert schedule["total_hours"] == 16.0
+
     def test_contract_preferred_over_linky(self):
         """find_contract_hc_slots retourne les slots contrat même si offPeakLabel existe."""
         slots = [{"start": "22:00:00", "end": "06:00:00"}]

--- a/tests/test_hc_sensor.py
+++ b/tests/test_hc_sensor.py
@@ -172,20 +172,20 @@ class TestFindContractHcSlots:
 
         assert schedule["ranges"] == [
             {
-                "start": "00:00",
+                "start": "21:00",
                 "end": "07:00",
-                "start_minutes": 0,
+                "start_minutes": 1260,
                 "end_minutes": 420,
-                "duration_minutes": 420,
-                "duration_hours": 7.0,
+                "duration_minutes": 600,
+                "duration_hours": 10.0,
             },
             {
                 "start": "11:00",
-                "end": "20:00",
+                "end": "17:00",
                 "start_minutes": 660,
-                "end_minutes": 1200,
-                "duration_minutes": 540,
-                "duration_hours": 9.0,
+                "end_minutes": 1020,
+                "duration_minutes": 360,
+                "duration_hours": 6.0,
             },
         ]
         assert schedule["total_hours"] == 16.0

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
 
 import pytest
 from homeassistant.util import dt as dt_util
@@ -13,7 +14,10 @@ from custom_components.octopus_french.const import (
     TARIFF_TYPE_TEMPO,
     TEMPO_STATISTICS_LABELS,
 )
-from custom_components.octopus_french.octopus_french import OctopusFrenchApiClient
+from custom_components.octopus_french.octopus_french import (
+    QUERY_GET_ACCOUNT_DATA,
+    OctopusFrenchApiClient,
+)
 from custom_components.octopus_french.sensor import _detect_tariff_type_for_meter
 from custom_components.octopus_french.sensors.descriptions import TEMPO_SENSORS
 from custom_components.octopus_french.sensors.electricity import (
@@ -161,6 +165,16 @@ class TestDetectTariffTypeTempo:
 
 class TestExtractTariffsTempo:
     """Tests pour l'extraction des 6 taux OctoTempo depuis l'API."""
+
+    def test_account_query_requests_consumption_rate_temporal_class(self) -> None:
+        """La requête doit demander temporalClass pour mapper les taux OctoTempo."""
+        consumption_rates_block = QUERY_GET_ACCOUNT_DATA.split(
+            "consumptionRates(first: 10)"
+        )[1].split("billingFrequency", 1)[0]
+
+        assert "temporalClass" in consumption_rates_block
+        assert "code" in consumption_rates_block
+        assert "registerId" in consumption_rates_block
 
     def _make_api_client(self) -> OctopusFrenchApiClient:
         """Créer un client API factice."""
@@ -574,6 +588,22 @@ class TestTempoCurrentRateSensor:
         assert attrs["tempo_color"] == "HIVER"
         assert attrs["period_type"] == "HP"
         assert attrs["prm_id"] == "TEST_PRM"
+
+    def test_octoflex_summer_daytime_uses_hc_rate_without_contract_slots(self) -> None:
+        """OctoTempo été utilise la plage HC de journée même sans timeSlots API."""
+        coordinator = self._make_coordinator("ETE", "tempo_ete_hc", 0.1325)
+        coordinator.data["agreements"][0]["product"] = {"code": "OCTOFLEX_4"}
+        coordinator.data["supply_points"] = {
+            "electricity": [{"prm": "TEST_PRM", "offPeakLabel": "HC (22H00-6H00)"}]
+        }
+        sensor = self._make_sensor(coordinator)
+
+        with patch(
+            "custom_components.octopus_french.sensors.electricity.dt_util.now",
+            return_value=datetime(2026, 7, 28, 13, 0, tzinfo=ZoneInfo("Europe/Paris")),
+        ):
+            assert sensor._compute_native_value() == pytest.approx(0.1325)
+            assert sensor._compute_attributes()["period_type"] == "HC"
 
 
 class TestCostToConsumptionLabel:


### PR DESCRIPTION
## Summary

Fixes #68.

This updates the OctoTempo current HC/HP detection so Tempo entities do not blindly fall back to the Linky `offPeakLabel` when the active contract is OctoTempo / `OCTOFLEX`.

Changes:
- request `temporalClass { code label registerId }` on `consumptionRates`, so OctoTempo rates can be mapped by provider temporal class instead of price order
- pass the current Tempo color into HC schedule resolution
- prefer the matching Tempo HC rate `time_slots` when available
- add an OctoTempo fallback schedule by current color when the API does not expose `timeSlots`
- use the same HC detection path for:
  - `binary_sensor.*_heures_creuses_actives`
  - `sensor.*_tarif_tempo_en_cours`

## Context

For OctoTempo, the Linky `offPeakLabel` may expose only a classic range such as `HC (22H00-6H00)`, while the subscribed OctoTempo product can have daytime HC windows.

In that case the integration currently exposes e.g.:

```yaml
hc_source: linky
hc_range_1: "22:00 - 06:00"
period_type: HP
```

while the OctoTempo active period is HC during the day.

## Test Plan

- [x] `.venv/bin/python -m pytest tests/test_hc_sensor.py tests/test_tempo.py -q`
- [x] `.venv/bin/python -m pytest tests -q`
- [x] `.venv/bin/python -m ruff check custom_components/octopus_french tests/test_hc_sensor.py tests/test_tempo.py`
- [x] `.venv/bin/python -m ruff format --check custom_components/octopus_french tests/test_hc_sensor.py tests/test_tempo.py`

Result: `194 passed`.

## Note for review

The fallback schedule is intentionally limited to OctoTempo / `OCTOFLEX` contracts and only used when contract `timeSlots` are not available. If the API reliably returns `timeSlots` once `temporalClass` is requested, those contract slots still take priority.
