### PR TITLE
fix: HTTP 400 getAccountData + plages HC et taux lus sur l'API (4.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,45 @@
+## [4.1.4] - 2026-08-03
+
+### 🚨 Correction bloquante — Plus aucune donnée récupérée en 4.1.3
+
+La 4.1.3 demandait le champ `temporalClass` sur le nœud `consumptionRates`, où il n'existe pas. L'API rejetait **toute** la requête `getAccountData` :
+
+```
+HTTP 400 — Cannot query field 'temporalClass' on type 'SupplyConsumptionRateType'
+```
+
+Comptes, contrats, tarifs et points de livraison devenaient inaccessibles. Le champ est retiré, un commentaire de garde-fou est posé dans la requête et un test dédié empêche sa réintroduction — la même régression était déjà survenue en 3.3.0, corrigée en 3.3.1.
+
+### 🐛 Correction — Inversion des tarifs Tempo Hiver HP / Rouge HC (issue [#37](https://github.com/domodom30/ha-octopus-french/issues/37))
+
+Le correctif annoncé en 3.2.7 était **inopérant depuis son annulation en 3.3.1** : le bloc `temporalClass` ayant été retiré de `consumptionRates` pour lever le HTTP 400, le mapping des taux reposait depuis lors uniquement sur le tri par ordre de prix — juste tant que la grille conserve l'ordre `ete_hc < hiver_hc < rouge_hc < ete_hp < hiver_hp < rouge_hp`, faux dès qu'elle en dévie.
+
+Le mapping par code est désormais réellement emprunté : les taux sont lus via `energySupplyRate.rates`, le seul champ dont les membres électricité (`ElectricitySupplyConsumptionRateType`) exposent `temporalClass`. Le tri par ordre de prix ne sert plus que de secours pour les comptes qui ne renvoient aucun code. Merci à [@harty911](https://github.com/harty911).
+
+### ✨ Plages heures creuses OctoTempo lues sur l'API (issue [#68](https://github.com/domodom30/ha-octopus-french/issues/68))
+
+Les horaires HC proviennent maintenant de `providerCalendar.temporalClasses[].description`, qui expose **une plage par classe temporelle** — donc par couleur sur un contrat OctoTempo (`HCE` / `HCHI` / `HCP`). Cela remplace les plages codées en dur introduites en 4.1.3, qui supposaient une souscription particulière et donnaient un état HC/HP faux pour toute autre.
+
+Les sources sont désormais hiérarchisées et traçables :
+
+1. `contract` — créneaux horaires du taux souscrit
+2. `calendar` — description de la classe temporelle du calendrier fournisseur
+3. `linky` — `offPeakLabel` du compteur, qui ne connaît qu'un seul jeu de plages
+4. `none` — aucune plage exploitable, l'entité reste indisponible
+
+Un nouvel attribut `hc_source` sur le binaire « Heures creuses actives » et sur le capteur « Tarif Tempo en cours » indique laquelle a été retenue. Un contrat Tempo contraint de se rabattre sur `offPeakLabel` le signale désormais au journal au lieu de le faire silencieusement. Merci à [@gaby49100](https://github.com/gaby49100).
+
+---
+
 ## [4.1.3] - 2026-08-02
 
 ### 🐛 Corrections
 
 Fix : [68](https://github.com/domodom30/ha-octopus-french/issues/68)
+
+> ⚠️ Version à ne pas utiliser : elle empêche toute récupération de données (voir 4.1.4).
+
+---
 
 ## [4.1.2] - 2026-07-26
 

--- a/custom_components/octopus_french/binary_sensor.py
+++ b/custom_components/octopus_french/binary_sensor.py
@@ -17,12 +17,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import OctopusFrenchDataUpdateCoordinator
-from .utils import (
-    find_contract_hc_slots,
-    get_tempo_color_for_prm,
-    parse_off_peak_hours,
-    parse_time_slots,
-)
+from .utils import get_tempo_color_for_prm, resolve_hc_schedule
 
 PARALLEL_UPDATES = 0
 
@@ -51,10 +46,10 @@ async def async_setup_entry(
         if not prm_id:
             continue
 
-        off_peak_label = meter.get("offPeakLabel")
-        contract_slots = find_contract_hc_slots(data, prm_id)
+        tempo_color = get_tempo_color_for_prm(data, prm_id)
+        schedule = resolve_hc_schedule(data, prm_id, tempo_color)
 
-        if contract_slots or off_peak_label:
+        if schedule["range_count"] > 0:
             sensors.append(
                 OctopusFrenchHcBinarySensor(
                     coordinator=coordinator,
@@ -124,33 +119,11 @@ class OctopusFrenchHcBinarySensor(
         Return the best available HC schedule from coordinator data.
 
         Returns a dict with keys: ranges, total_hours, range_count, source, type.
-        'source' is 'contract' or 'linky'.
+        'source' is 'contract', 'calendar', 'linky' or 'none'.
         """
         data = self.coordinator.data or {}
-
         tempo_color = get_tempo_color_for_prm(data, self._prm_id)
-        if contract_slots := find_contract_hc_slots(data, self._prm_id, tempo_color):
-            schedule = parse_time_slots(contract_slots)
-            if schedule["range_count"] > 0:
-                return schedule
-
-        supply_points = data.get("supply_points", {})
-        for meter in supply_points.get("electricity", []):
-            if meter.get("prm") == self._prm_id:
-                off_peak_label = meter.get("offPeakLabel")
-                if off_peak_label:
-                    schedule = parse_off_peak_hours(off_peak_label)
-                    schedule["source"] = "linky"
-                    return schedule
-                break
-
-        return {
-            "ranges": [],
-            "total_hours": 0.0,
-            "range_count": 0,
-            "source": "none",
-            "type": None,
-        }
+        return resolve_hc_schedule(data, self._prm_id, tempo_color)
 
     @property
     def available(self) -> bool:

--- a/custom_components/octopus_french/manifest.json
+++ b/custom_components/octopus_french/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/domodom30/ha-octopus-french/issues",
   "requirements": ["PyJWT>=2.10.1"],
-  "version": "4.1.3"
+  "version": "4.1.4"
 }

--- a/custom_components/octopus_french/octopus_french.py
+++ b/custom_components/octopus_french/octopus_french.py
@@ -185,11 +185,9 @@ query getAccountData($accountNumber: String!, $activeAt: DateTime!) {
                   pricePerUnitWithTaxes
                   validFrom
                   validTo
-                  temporalClass {
-                    code
-                    label
-                    registerId
-                  }
+                  # NE PAS ajouter temporalClass ici : le champ n'existe pas sur
+                  # SupplyConsumptionRateType et fait échouer toute la requête
+                  # (HTTP 400). Régression déjà vue en 3.3.0 puis en 4.1.3.
                   timeSlots {
                     startAt
                     endAt

--- a/custom_components/octopus_french/octopus_french.py
+++ b/custom_components/octopus_french/octopus_french.py
@@ -188,9 +188,54 @@ query getAccountData($accountNumber: String!, $activeAt: DateTime!) {
                   # NE PAS ajouter temporalClass ici : le champ n'existe pas sur
                   # SupplyConsumptionRateType et fait échouer toute la requête
                   # (HTTP 400). Régression déjà vue en 3.3.0 puis en 4.1.3.
+                  # Pour obtenir temporalClass, utiliser le bloc `rates` ci-dessous.
                   timeSlots {
                     startAt
                     endAt
+                  }
+                }
+              }
+            }
+            # `rates` renvoie l'interface SupplyProductRateInterface : contrairement
+            # à consumptionRates, ses membres électricité portent temporalClass
+            # (code + description des plages horaires). Le gaz retombe sur
+            # SupplyConsumptionRateType, sans temporalClass.
+            rates(first: 20) {
+              edges {
+                node {
+                  __typename
+                  currency
+                  pricePerUnit
+                  unitType
+                  pricePerUnitWithTaxes
+                  validFrom
+                  validTo
+                  ... on ElectricitySupplyConsumptionRateType {
+                    timeSlots {
+                      startAt
+                      endAt
+                    }
+                    temporalClass {
+                      code
+                      label
+                      description
+                      registerId
+                    }
+                  }
+                  # ElectricityConsumptionRateType n'expose PAS timeSlots (HTTP 400).
+                  ... on ElectricityConsumptionRateType {
+                    temporalClass {
+                      code
+                      label
+                      description
+                      registerId
+                    }
+                  }
+                  ... on SupplyConsumptionRateType {
+                    timeSlots {
+                      startAt
+                      endAt
+                    }
                   }
                 }
               }
@@ -846,6 +891,53 @@ class OctopusFrenchApiClient:
         "HIVER": "HIVER",
     }
 
+    @staticmethod
+    def _parse_rate_nodes(energy_rate: dict[str, Any]) -> list[dict[str, Any]]:
+        """
+        Normalise les taux de consommation d'un energySupplyRate.
+
+        `rates` est privilégié sur `consumptionRates` : c'est le seul des deux
+        dont les membres électricité exposent `temporalClass` (code de classe et
+        description des plages horaires). `consumptionRates` sert de secours pour
+        les comptes où `rates` ne remonte rien.
+        """
+        edges = (energy_rate.get("rates") or {}).get("edges") or []
+        if not edges:
+            edges = (energy_rate.get("consumptionRates") or {}).get("edges") or []
+
+        rates: list[dict[str, Any]] = []
+        for edge in edges:
+            node = edge.get("node") or {}
+            # `rates` peut aussi contenir l'abonnement : seuls les taux au kWh
+            # nous intéressent ici (l'abonnement vient de standingRate).
+            if "Standing" in (node.get("__typename") or ""):
+                continue
+            try:
+                temporal_class = node.get("temporalClass") or {}
+                time_slots = node.get("timeSlots") or []
+                rates.append(
+                    {
+                        "price_ht": round(float(node.get("pricePerUnit", 0)) / 100, 4),
+                        "price_ttc": round(
+                            float(node.get("pricePerUnitWithTaxes", 0)) / 100, 4
+                        ),
+                        "currency": node.get("currency"),
+                        "unit_type": node.get("unitType"),
+                        "temporal_class_code": temporal_class.get("code"),
+                        "temporal_class_label": temporal_class.get("label"),
+                        "temporal_class_description": temporal_class.get("description"),
+                        "temporal_class_register_id": temporal_class.get("registerId"),
+                        "time_slots": [
+                            {"start": s.get("startAt"), "end": s.get("endAt")}
+                            for s in time_slots
+                        ],
+                    }
+                )
+            except (ValueError, TypeError) as e:
+                _LOGGER.warning("Error parsing consumption rate: %s", e)
+
+        return rates
+
     def _extract_tariffs(self, energy_rate: dict[str, Any]) -> dict[str, Any]:
         """Extract tariff information from energySupplyRate."""
         tariffs: dict[str, Any] = {
@@ -868,31 +960,7 @@ class OctopusFrenchApiClient:
             except (ValueError, TypeError) as e:
                 _LOGGER.warning("Error parsing standing rate: %s", e)
 
-        consumption_rates = []
-        for rate_edge in (energy_rate.get("consumptionRates") or {}).get("edges", []):
-            rate = rate_edge.get("node") or {}
-            try:
-                temporal_class = rate.get("temporalClass") or {}
-                time_slots = rate.get("timeSlots") or []
-                consumption_rates.append(
-                    {
-                        "price_ht": round(float(rate.get("pricePerUnit", 0)) / 100, 4),
-                        "price_ttc": round(
-                            float(rate.get("pricePerUnitWithTaxes", 0)) / 100, 4
-                        ),
-                        "currency": rate.get("currency"),
-                        "unit_type": rate.get("unitType"),
-                        "temporal_class_code": temporal_class.get("code"),
-                        "temporal_class_label": temporal_class.get("label"),
-                        "temporal_class_register_id": temporal_class.get("registerId"),
-                        "time_slots": [
-                            {"start": s.get("startAt"), "end": s.get("endAt")}
-                            for s in time_slots
-                        ],
-                    }
-                )
-            except (ValueError, TypeError) as e:
-                _LOGGER.warning("Error parsing consumption rate: %s", e)
+        consumption_rates = self._parse_rate_nodes(energy_rate)
 
         mapped_by_code = False
         for rate in consumption_rates:

--- a/custom_components/octopus_french/sensors/electricity.py
+++ b/custom_components/octopus_french/sensors/electricity.py
@@ -19,13 +19,11 @@ from ..const import (
 )
 from ..coordinator import OctopusFrenchDataUpdateCoordinator
 from ..utils import (
-    find_contract_hc_slots,
     get_tariff_rate_for_key,
     get_tempo_color_for_prm,
     normalize_consumption_label,
     normalize_provider_calendar,
-    parse_off_peak_hours,
-    parse_time_slots,
+    resolve_hc_schedule,
 )
 from .descriptions import OctopusIndexSensorDescription
 
@@ -852,26 +850,19 @@ class OctopusTempoCurrentRateSensor(
         return {
             "tempo_color": color,
             "period_type": "HC" if is_hc else ("HP" if is_hc is not None else None),
+            "hc_source": self._resolve_hc_schedule()["source"],
             "prm_id": self._prm_id,
         }
 
-    def _is_currently_hc(self) -> bool:
-        """Return True if the current time falls within an HC (off-peak) period."""
+    def _resolve_hc_schedule(self) -> dict[str, Any]:
+        """Return the HC schedule applicable to this PRM, with its provenance."""
         data = self.coordinator.data or {}
         tempo_color = get_tempo_color_for_prm(data, self._prm_id)
-        contract_slots = find_contract_hc_slots(data, self._prm_id, tempo_color)
-        if contract_slots:
-            schedule = parse_time_slots(contract_slots)
-        else:
-            off_peak_label = None
-            for meter in data.get("supply_points", {}).get("electricity", []):
-                if meter.get("prm") == self._prm_id:
-                    off_peak_label = meter.get("offPeakLabel")
-                    break
-            if not off_peak_label:
-                return False
-            schedule = parse_off_peak_hours(off_peak_label)
+        return resolve_hc_schedule(data, self._prm_id, tempo_color)
 
+    def _is_currently_hc(self) -> bool:
+        """Return True if the current time falls within an HC (off-peak) period."""
+        schedule = self._resolve_hc_schedule()
         if not schedule.get("ranges"):
             return False
 

--- a/custom_components/octopus_french/utils.py
+++ b/custom_components/octopus_french/utils.py
@@ -19,16 +19,16 @@ _TEMPO_COLOR_TO_HC_KEY = {
     "ROUGE": "tempo_rouge_hc",
 }
 
-_OCTOFLEX_DEFAULT_HC_SLOTS = {
-    # OctoTempo exposes 16 off-peak hours in summer: 21:00-07:00 and 11:00-17:00.
-    "ETE": [
-        {"start": "21:00:00", "end": "07:00:00"},
-        {"start": "11:00:00", "end": "17:00:00"},
-    ],
-    # Winter/red days expose 10 off-peak hours: 21:00-07:00.
-    "HIVER": [{"start": "21:00:00", "end": "07:00:00"}],
-    "ROUGE": [{"start": "21:00:00", "end": "07:00:00"}],
+# Code de la classe temporelle HC du calendrier fournisseur, par couleur Tempo.
+_TEMPO_COLOR_TO_HC_TEMPORAL_CODE = {
+    "ETE": "HCE",
+    "HIVER": "HCHI",
+    "ROUGE": "HCP",
 }
+
+# PRM pour lesquels le repli sur offPeakLabel a déjà été signalé, pour ne pas
+# répéter l'avertissement à chaque rafraîchissement du coordinator.
+_LINKY_FALLBACK_WARNED: set[str] = set()
 
 
 def parse_off_peak_hours(off_peak_label: str | None) -> dict[str, Any]:
@@ -168,13 +168,106 @@ def find_contract_hc_slots(
             ):
                 return slots
 
-        product_code = ((agreement.get("product") or {}).get("code") or "").upper()
-        if any(kw in product_code for kw in TEMPO_PRODUCT_CODE_KEYWORDS):
-            color = (tempo_color or "").upper()
-            if slots := _OCTOFLEX_DEFAULT_HC_SLOTS.get(color):
-                return slots
+    return None
+
+
+def _find_electricity_meter(data: dict[str, Any], prm_id: str) -> dict[str, Any] | None:
+    """Retourne le compteur électrique correspondant au PRM, ou None."""
+    for meter in data.get("supply_points", {}).get("electricity", []):
+        if meter.get("prm") == prm_id:
+            return meter
+    return None
+
+
+def find_calendar_hc_ranges(
+    data: dict[str, Any], prm_id: str, tempo_color: str | None = None
+) -> dict[str, Any] | None:
+    """
+    Dérive les plages HC depuis le calendrier fournisseur du compteur.
+
+    Chaque classe temporelle de `providerCalendar` porte ses horaires dans son
+    champ `description` (ex. `"0H50-6H50;14H50-16H50"`). Un contrat OctoTempo
+    expose une classe HC par couleur (HCE / HCHI / HCP), ce qui donne la plage
+    réellement souscrite sans avoir à la deviner.
+
+    Renvoie None si la description est absente ou illisible.
+    """
+    meter = _find_electricity_meter(data, prm_id)
+    if not meter:
+        return None
+
+    wanted = _TEMPO_COLOR_TO_HC_TEMPORAL_CODE.get((tempo_color or "").upper(), "HC")
+    for temporal_class in meter.get("provider_temporal_classes") or []:
+        if (temporal_class.get("code") or "").upper() != wanted:
+            continue
+        schedule = parse_off_peak_hours(temporal_class.get("description"))
+        if schedule["range_count"] > 0:
+            schedule["type"] = "HC"
+            schedule["source"] = "calendar"
+            return schedule
+        return None
 
     return None
+
+
+def _is_tempo_contract(data: dict[str, Any], prm_id: str) -> bool:
+    """Indique si le PRM est sur un contrat Tempo (produit ou classes temporelles)."""
+    for agreement in data.get("agreements", []):
+        if agreement.get("prm") != prm_id or not agreement.get("is_active"):
+            continue
+        product_code = ((agreement.get("product") or {}).get("code") or "").upper()
+        if any(kw in product_code for kw in TEMPO_PRODUCT_CODE_KEYWORDS):
+            return True
+
+    meter = _find_electricity_meter(data, prm_id) or {}
+    codes = {
+        (tc.get("code") or "").upper()
+        for tc in meter.get("provider_temporal_classes") or []
+    }
+    return bool(codes & TEMPO_TEMPORAL_CLASS_CODES)
+
+
+def resolve_hc_schedule(
+    data: dict[str, Any], prm_id: str, tempo_color: str | None = None
+) -> dict[str, Any]:
+    """
+    Retourne les plages HC applicables au PRM, avec leur provenance.
+
+    Sources par ordre de fiabilité décroissante, exposées via la clé `source` :
+    `contract` (créneaux du taux souscrit), `calendar` (description de la classe
+    temporelle du calendrier fournisseur), `linky` (offPeakLabel du compteur,
+    qui ne connaît qu'un seul jeu de plages) et `none`.
+    """
+    if contract_slots := find_contract_hc_slots(data, prm_id, tempo_color):
+        schedule = parse_time_slots(contract_slots)
+        if schedule["range_count"] > 0:
+            return schedule
+
+    if schedule := find_calendar_hc_ranges(data, prm_id, tempo_color):
+        return schedule
+
+    meter = _find_electricity_meter(data, prm_id) or {}
+    if off_peak_label := meter.get("offPeakLabel"):
+        schedule = parse_off_peak_hours(off_peak_label)
+        schedule["source"] = "linky"
+        if _is_tempo_contract(data, prm_id) and prm_id not in _LINKY_FALLBACK_WARNED:
+            _LINKY_FALLBACK_WARNED.add(prm_id)
+            _LOGGER.warning(
+                "PRM %s : contrat Tempo sans plages HC exploitables côté contrat "
+                "ni calendrier fournisseur — repli sur offPeakLabel Linky ('%s'), "
+                "qui ignore les plages HC de journée propres à chaque couleur",
+                prm_id,
+                off_peak_label,
+            )
+        return schedule
+
+    return {
+        "type": None,
+        "ranges": [],
+        "total_hours": 0.0,
+        "range_count": 0,
+        "source": "none",
+    }
 
 
 def get_tempo_color_for_prm(data: dict[str, Any], prm_id: str) -> str | None:

--- a/tests/test_hc_sensor.py
+++ b/tests/test_hc_sensor.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from custom_components.octopus_french.utils import (
+    find_calendar_hc_ranges,
     find_contract_hc_slots,
     parse_time_slots,
+    resolve_hc_schedule,
 )
 
 
@@ -146,50 +148,6 @@ class TestFindContractHcSlots:
         result = find_contract_hc_slots(data, "PRM1")
         assert result == slots
 
-    def test_octoflex_fallback_uses_tempo_color_schedule(self):
-        """OctoTempo ne doit pas retomber sur offPeakLabel si le contrat n'a pas de timeSlots."""
-        data = {
-            "agreements": [
-                {
-                    "prm": "PRM1",
-                    "is_active": True,
-                    "product": {"code": "OCTOFLEX_4"},
-                    "tariffs": {
-                        "consumption": {
-                            "tempo_ete_hp": {"price_ttc": 0.1575},
-                            "tempo_ete_hc": {"price_ttc": 0.1325},
-                        }
-                    },
-                }
-            ],
-            "supply_points": {
-                "electricity": [{"id": "PRM1", "offPeakLabel": "HC (22H00-6H00)"}]
-            },
-        }
-
-        slots = find_contract_hc_slots(data, "PRM1", tempo_color="ETE")
-        schedule = parse_time_slots(slots or [])
-
-        assert schedule["ranges"] == [
-            {
-                "start": "21:00",
-                "end": "07:00",
-                "start_minutes": 1260,
-                "end_minutes": 420,
-                "duration_minutes": 600,
-                "duration_hours": 10.0,
-            },
-            {
-                "start": "11:00",
-                "end": "17:00",
-                "start_minutes": 660,
-                "end_minutes": 1020,
-                "duration_minutes": 360,
-                "duration_hours": 6.0,
-            },
-        ]
-        assert schedule["total_hours"] == 16.0
-
     def test_contract_preferred_over_linky(self):
         """find_contract_hc_slots retourne les slots contrat même si offPeakLabel existe."""
         slots = [{"start": "22:00:00", "end": "06:00:00"}]
@@ -200,3 +158,144 @@ class TestFindContractHcSlots:
         )
         result = find_contract_hc_slots(data, "PRM1")
         assert result == slots
+
+
+def _make_calendar_data(
+    prm: str,
+    temporal_classes: list[dict],
+    off_peak_label: str | None = None,
+    product_code: str = "OCTOFLEX_4_V4",
+) -> dict:
+    """coordinator.data avec un calendrier fournisseur, sans timeSlots contrat."""
+    return {
+        "supply_points": {
+            "electricity": [
+                {
+                    "prm": prm,
+                    "offPeakLabel": off_peak_label,
+                    "provider_temporal_classes": temporal_classes,
+                }
+            ]
+        },
+        "agreements": [
+            {
+                "prm": prm,
+                "is_active": True,
+                "product": {"code": product_code},
+                "tariffs": {"consumption": {}},
+            }
+        ],
+    }
+
+
+# Classes temporelles d'un contrat OctoTempo : une description par couleur.
+_OCTOTEMPO_CLASSES = [
+    {"code": "HPE", "label": "HP Été", "description": ""},
+    {"code": "HCE", "label": "HC Été", "description": "21H00-7H00;11H00-17H00"},
+    {"code": "HPHI", "label": "HP Hiver", "description": ""},
+    {"code": "HCHI", "label": "HC Hiver", "description": "21H00-7H00"},
+    {"code": "HPP", "label": "HP Rouge", "description": ""},
+    {"code": "HCP", "label": "HC Rouge", "description": "2H00-6H00"},
+]
+
+
+class TestFindCalendarHcRanges:
+    """Les plages HC dérivées de providerCalendar.temporalClasses[].description."""
+
+    def test_hphc_classic(self):
+        """Format réel d'un compteur HP/HC : deux plages séparées par ';'."""
+        data = _make_calendar_data(
+            "PRM1",
+            [
+                {"code": "HC", "label": "Heures creuses", "description": "0H50-6H50"},
+                {"code": "HP", "label": "Heures Pleines", "description": ""},
+            ],
+            product_code="ECO_CONSO_FIXE_3",
+        )
+        schedule = find_calendar_hc_ranges(data, "PRM1")
+
+        assert schedule is not None
+        assert schedule["source"] == "calendar"
+        assert schedule["type"] == "HC"
+        assert schedule["ranges"][0]["start"] == "00:50"
+        assert schedule["ranges"][0]["end"] == "06:50"
+        assert schedule["total_hours"] == 6.0
+
+    def test_tempo_color_selects_matching_class(self):
+        """Chaque couleur lit la description de SA classe HC (HCE/HCHI/HCP)."""
+        data = _make_calendar_data("PRM1", _OCTOTEMPO_CLASSES)
+
+        ete = find_calendar_hc_ranges(data, "PRM1", tempo_color="ETE")
+        assert ete is not None
+        assert [(r["start"], r["end"]) for r in ete["ranges"]] == [
+            ("21:00", "07:00"),
+            ("11:00", "17:00"),
+        ]
+        assert ete["total_hours"] == 16.0
+
+        hiver = find_calendar_hc_ranges(data, "PRM1", tempo_color="HIVER")
+        assert hiver is not None
+        assert [(r["start"], r["end"]) for r in hiver["ranges"]] == [("21:00", "07:00")]
+
+        rouge = find_calendar_hc_ranges(data, "PRM1", tempo_color="ROUGE")
+        assert rouge is not None
+        assert [(r["start"], r["end"]) for r in rouge["ranges"]] == [("02:00", "06:00")]
+
+    def test_empty_description_returns_none(self):
+        """Une description vide ne produit aucune plage inventée."""
+        data = _make_calendar_data(
+            "PRM1", [{"code": "HCE", "label": "HC Été", "description": ""}]
+        )
+        assert find_calendar_hc_ranges(data, "PRM1", tempo_color="ETE") is None
+
+    def test_unknown_prm_returns_none(self):
+        """Un PRM absent des supply points renvoie None."""
+        data = _make_calendar_data("PRM1", _OCTOTEMPO_CLASSES)
+        assert find_calendar_hc_ranges(data, "PRM_AUTRE", tempo_color="ETE") is None
+
+
+class TestResolveHcSchedule:
+    """Ordre de priorité contrat → calendrier → linky → none."""
+
+    def test_contract_wins(self):
+        """Les créneaux du contrat priment sur le calendrier et sur Linky."""
+        data = _make_calendar_data(
+            "PRM1", _OCTOTEMPO_CLASSES, off_peak_label="HC (22H00-6H00)"
+        )
+        data["agreements"][0]["tariffs"]["consumption"]["tempo_ete_hc"] = {
+            "time_slots": [{"start": "01:00:00", "end": "05:00:00"}]
+        }
+
+        schedule = resolve_hc_schedule(data, "PRM1", tempo_color="ETE")
+        assert schedule["source"] == "contract"
+        assert [(r["start"], r["end"]) for r in schedule["ranges"]] == [
+            ("01:00", "05:00")
+        ]
+
+    def test_calendar_used_when_contract_has_no_slots(self):
+        """Sans timeSlots contrat, on lit le calendrier — pas offPeakLabel."""
+        data = _make_calendar_data(
+            "PRM1", _OCTOTEMPO_CLASSES, off_peak_label="HC (22H00-6H00)"
+        )
+
+        schedule = resolve_hc_schedule(data, "PRM1", tempo_color="ETE")
+        assert schedule["source"] == "calendar"
+        assert schedule["total_hours"] == 16.0
+
+    def test_linky_last_resort(self):
+        """Sans contrat ni calendrier exploitable, on retombe sur offPeakLabel."""
+        data = _make_calendar_data("PRM1", [], off_peak_label="HC (22H00-6H00)")
+
+        schedule = resolve_hc_schedule(data, "PRM1", tempo_color="ETE")
+        assert schedule["source"] == "linky"
+        assert [(r["start"], r["end"]) for r in schedule["ranges"]] == [
+            ("22:00", "06:00")
+        ]
+
+    def test_none_when_no_source(self):
+        """Aucune source exploitable : plage vide, l'entité devient indisponible."""
+        data = _make_calendar_data("PRM1", [], off_peak_label=None)
+
+        schedule = resolve_hc_schedule(data, "PRM1", tempo_color="ETE")
+        assert schedule["source"] == "none"
+        assert schedule["range_count"] == 0

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -166,15 +166,26 @@ class TestDetectTariffTypeTempo:
 class TestExtractTariffsTempo:
     """Tests pour l'extraction des 6 taux OctoTempo depuis l'API."""
 
-    def test_account_query_requests_consumption_rate_temporal_class(self) -> None:
-        """La requête doit demander temporalClass pour mapper les taux OctoTempo."""
+    def test_account_query_does_not_request_consumption_rate_temporal_class(
+        self,
+    ) -> None:
+        """temporalClass n'existe pas sur SupplyConsumptionRateType → HTTP 400.
+
+        Régression déjà survenue en 3.3.0 puis en 4.1.3 : le champ y avait été
+        ajouté, ce qui faisait rejeter toute la requête getAccountData.
+        """
         consumption_rates_block = QUERY_GET_ACCOUNT_DATA.split(
             "consumptionRates(first: 10)"
         )[1].split("billingFrequency", 1)[0]
+        # Le garde-fou en commentaire dans la requête mentionne le champ : on ne
+        # regarde que les lignes réellement envoyées à l'API.
+        queried_fields = "\n".join(
+            line
+            for line in consumption_rates_block.splitlines()
+            if not line.lstrip().startswith("#")
+        )
 
-        assert "temporalClass" in consumption_rates_block
-        assert "code" in consumption_rates_block
-        assert "registerId" in consumption_rates_block
+        assert "temporalClass" not in queried_fields
 
     def _make_api_client(self) -> OctopusFrenchApiClient:
         """Créer un client API factice."""

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -174,9 +174,11 @@ class TestExtractTariffsTempo:
         Régression déjà survenue en 3.3.0 puis en 4.1.3 : le champ y avait été
         ajouté, ce qui faisait rejeter toute la requête getAccountData.
         """
+        # temporalClass est légitime dans le bloc `rates` qui suit : on borne le
+        # découpage à consumptionRates seul.
         consumption_rates_block = QUERY_GET_ACCOUNT_DATA.split(
             "consumptionRates(first: 10)"
-        )[1].split("billingFrequency", 1)[0]
+        )[1].split("rates(first: 20)", 1)[0]
         # Le garde-fou en commentaire dans la requête mentionne le champ : on ne
         # regarde que les lignes réellement envoyées à l'API.
         queried_fields = "\n".join(
@@ -191,27 +193,116 @@ class TestExtractTariffsTempo:
         """Créer un client API factice."""
         return OctopusFrenchApiClient.__new__(OctopusFrenchApiClient)
 
-    def _make_consumption_rates(
-        self, prices: list[float], codes: list[str] | None = None
-    ) -> dict:
+    def _make_consumption_rates(self, prices: list[float]) -> dict:
         """
-        Construit une réponse consumptionRates avec les prix indiqués.
+        Construit une réponse `consumptionRates` avec les prix indiqués.
 
-        Si `codes` est fourni, chaque taux porte un temporalClass.code (mapping
-        fiable par code) ; sinon le fallback par ordre de prix est emprunté.
+        Ce champ n'expose jamais temporalClass (le demander déclenche un
+        HTTP 400) : ces taux empruntent donc le fallback par ordre de prix.
+        Pour le mapping par code, voir `_make_rates`.
         """
-        edges = []
-        for i, p in enumerate(prices):
-            node: dict = {
-                "pricePerUnit": str(p * 100),
-                "pricePerUnitWithTaxes": str(p * 100),
-                "currency": "EUR",
-                "unitType": "kWh",
+        edges = [
+            {
+                "node": {
+                    "pricePerUnit": str(p * 100),
+                    "pricePerUnitWithTaxes": str(p * 100),
+                    "currency": "EUR",
+                    "unitType": "kWh",
+                }
             }
-            if codes is not None:
-                node["temporalClass"] = {"code": codes[i]}
-            edges.append({"node": node})
+            for p in prices
+        ]
         return {"standingRate": None, "consumptionRates": {"edges": edges}}
+
+    def _make_rates(self, rates: list[tuple[float, str, str]]) -> dict:
+        """
+        Construit une réponse `rates` telle que renvoyée par l'API.
+
+        Chaque entrée est (prix, code de classe temporelle, description horaire),
+        au format réel d'`ElectricitySupplyConsumptionRateType`.
+        """
+        edges = [
+            {
+                "node": {
+                    "__typename": "ElectricitySupplyConsumptionRateType",
+                    "pricePerUnit": str(price * 100),
+                    "pricePerUnitWithTaxes": str(price * 100),
+                    "currency": "EURO_CENTS",
+                    "unitType": "KWH_CONSUMPION",
+                    "timeSlots": [],
+                    "temporalClass": {
+                        "code": code,
+                        "label": code,
+                        "description": description,
+                        "registerId": 1,
+                    },
+                }
+            }
+            for price, code, description in rates
+        ]
+        return {"standingRate": None, "rates": {"edges": edges}}
+
+    def test_rates_map_tempo_keys_by_code(self) -> None:
+        """Les 6 taux OctoTempo sont mappés par temporalClass.code, pas par prix."""
+        client = self._make_api_client()
+        # Prix volontairement désordonnés : un mapping par prix se tromperait.
+        energy_rate = self._make_rates(
+            [
+                (0.60, "HPP", ""),
+                (0.10, "HCE", "21H00-7H00;11H00-17H00"),
+                (0.16, "HPE", ""),
+                (0.40, "HCP", "2H00-6H00"),
+                (0.20, "HPHI", ""),
+                (0.12, "HCHI", "21H00-7H00"),
+            ]
+        )
+        consumption = client._extract_tariffs(energy_rate)["consumption"]
+
+        assert consumption["tempo_rouge_hp"]["price_ttc"] == pytest.approx(0.60)
+        assert consumption["tempo_ete_hc"]["price_ttc"] == pytest.approx(0.10)
+        assert consumption["tempo_rouge_hc"]["price_ttc"] == pytest.approx(0.40)
+        assert consumption["tempo_hiver_hc"]["price_ttc"] == pytest.approx(0.12)
+
+    def test_rates_carry_temporal_class_description(self) -> None:
+        """La description horaire de la classe est conservée sur le taux."""
+        client = self._make_api_client()
+        energy_rate = self._make_rates([(0.10, "HCE", "21H00-7H00;11H00-17H00")])
+        consumption = client._extract_tariffs(energy_rate)["consumption"]
+
+        assert (
+            consumption["tempo_ete_hc"]["temporal_class_description"]
+            == "21H00-7H00;11H00-17H00"
+        )
+
+    def test_rates_ignore_standing_rate_nodes(self) -> None:
+        """Un éventuel nœud d'abonnement dans `rates` n'est pas pris pour un taux kWh."""
+        client = self._make_api_client()
+        energy_rate = self._make_rates([(0.10, "HC", "0H50-6H50")])
+        energy_rate["rates"]["edges"].insert(
+            0,
+            {
+                "node": {
+                    "__typename": "ElectricityStandingRateType",
+                    "pricePerUnit": "5000",
+                    "pricePerUnitWithTaxes": "6000",
+                    "currency": "EURO_CENTS",
+                    "unitType": "DAY",
+                }
+            },
+        )
+        consumption = client._extract_tariffs(energy_rate)["consumption"]
+
+        assert consumption["heures_creuses"]["price_ttc"] == pytest.approx(0.10)
+        assert "base" not in consumption
+
+    def test_consumption_rates_used_when_rates_absent(self) -> None:
+        """Sans `rates`, l'extraction retombe sur `consumptionRates`."""
+        client = self._make_api_client()
+        energy_rate = self._make_consumption_rates([0.20, 0.10])
+        consumption = client._extract_tariffs(energy_rate)["consumption"]
+
+        assert consumption["heures_pleines"]["price_ttc"] == pytest.approx(0.20)
+        assert consumption["heures_creuses"]["price_ttc"] == pytest.approx(0.10)
 
     def test_six_rates_assigns_tempo_keys(self) -> None:
         """Avec 6 taux, les clés Tempo doivent être présentes dans consumption."""
@@ -266,12 +357,24 @@ class TestExtractTariffsTempo:
         assert consumption["tempo_rouge_hc"]["price_ttc"] == pytest.approx(0.1575)
 
     def test_mapping_by_temporal_class_code_ignores_price_order(self) -> None:
-        """Avec temporalClass.code, l'affectation est déterministe (pas par prix)."""
+        """
+        Non-régression issue #37 : l'affectation suit temporalClass.code, pas le prix.
+
+        Grille réelle de l'issue, dans le désordre. Le mapping par code n'est
+        atteignable que via `rates` : `consumptionRates` n'expose pas
+        temporalClass, et le demander à cet endroit casse toute la requête.
+        """
         client = self._make_api_client()
-        # Prix volontairement dans le désordre ; les codes font foi.
-        prices = [0.1871, 0.1575, 0.1296, 0.7562, 0.1486, 0.1609]
-        codes = ["HPHI", "HCP", "HCE", "HPP", "HCHI", "HPE"]
-        energy_rate = self._make_consumption_rates(prices, codes=codes)
+        energy_rate = self._make_rates(
+            [
+                (0.1871, "HPHI", ""),
+                (0.1575, "HCP", "2H00-6H00"),
+                (0.1296, "HCE", "21H00-7H00;11H00-17H00"),
+                (0.7562, "HPP", ""),
+                (0.1486, "HCHI", "21H00-7H00"),
+                (0.1609, "HPE", ""),
+            ]
+        )
         consumption = client._extract_tariffs(energy_rate)["consumption"]
 
         assert consumption["tempo_hiver_hp"]["price_ttc"] == pytest.approx(0.1871)
@@ -600,12 +703,25 @@ class TestTempoCurrentRateSensor:
         assert attrs["period_type"] == "HP"
         assert attrs["prm_id"] == "TEST_PRM"
 
-    def test_octoflex_summer_daytime_uses_hc_rate_without_contract_slots(self) -> None:
-        """OctoTempo été utilise la plage HC de journée même sans timeSlots API."""
+    def test_octoflex_summer_daytime_uses_calendar_hc_range(self) -> None:
+        """OctoTempo été : la plage HC de journée vient du calendrier fournisseur.
+
+        offPeakLabel n'expose qu'une seule plage nocturne et donnerait HP à 13h ;
+        la description de la classe HCE porte la vraie plage 11H-17H.
+        """
         coordinator = self._make_coordinator("ETE", "tempo_ete_hc", 0.1325)
-        coordinator.data["agreements"][0]["product"] = {"code": "OCTOFLEX_4"}
+        coordinator.data["agreements"][0]["product"] = {"code": "OCTOFLEX_4_V4"}
         coordinator.data["supply_points"] = {
-            "electricity": [{"prm": "TEST_PRM", "offPeakLabel": "HC (22H00-6H00)"}]
+            "electricity": [
+                {
+                    "prm": "TEST_PRM",
+                    "offPeakLabel": "HC (22H00-6H00)",
+                    "provider_temporal_classes": [
+                        {"code": "HCE", "description": "21H00-7H00;11H00-17H00"},
+                        {"code": "HPE", "description": ""},
+                    ],
+                }
+            ]
         }
         sensor = self._make_sensor(coordinator)
 
@@ -614,7 +730,10 @@ class TestTempoCurrentRateSensor:
             return_value=datetime(2026, 7, 28, 13, 0, tzinfo=ZoneInfo("Europe/Paris")),
         ):
             assert sensor._compute_native_value() == pytest.approx(0.1325)
-            assert sensor._compute_attributes()["period_type"] == "HC"
+            attrs = sensor._compute_attributes()
+
+        assert attrs["period_type"] == "HC"
+        assert attrs["hc_source"] == "calendar"
 
 
 class TestCostToConsumptionLabel:


### PR DESCRIPTION
## Contexte

La 4.1.3 (PR #69) a réintroduit le champ `temporalClass` sur le nœud `consumptionRates`, où il n'existe pas. L'API rejette alors **toute** la requête `getAccountData` :

```
HTTP 400 — Cannot query field 'temporalClass' on type 'SupplyConsumptionRateType'
```

Plus aucune donnée n'est récupérée : comptes, contrats, tarifs, points de livraison. La même régression était survenue en 3.3.0 et avait été corrigée en 3.3.1 (commit `d1f9b79`).

Cette PR corrige le blocage, puis va chercher au bon endroit les informations que la 4.1.3 tentait d'obtenir.

## Commits

### `fix: HTTP 400 sur getAccountData` — correctif bloquant, isolable

Retrait du champ fautif, commentaire de garde-fou dans la requête et test de non-régression. Ce commit est autonome et cherry-pickable si un hotfix immédiat est préféré.

### `feat: plages HC et mapping des taux lus sur l'API` — issues #37 et #68

L'introspection du schéma Kraken (`tools/schema.py`) et des requêtes sur un compte réel ont montré que l'API expose bien ce qui était deviné.

**Plages horaires HC — issue #68**

`providerCalendar.temporalClasses[].description` porte les horaires, avec **une description par classe temporelle**, donc une plage par couleur sur OctoTempo (`HCE` / `HCHI` / `HCP`) :

```json
{"code": "HC", "label": "Heures creuses", "description": "0H50-6H50;14H50-16H50"}
```

Ce bloc était déjà demandé et déjà stocké dans `provider_temporal_classes` — seul `code` était lu. Le format est celui que `parse_off_peak_hours()` sait déjà parser.

Cela remplace `_OCTOFLEX_DEFAULT_HC_SLOTS`, la table codée en dur ajoutée en 4.1.3, qui supposait une souscription particulière et donnait un état HC/HP faux pour toute autre.

Nouvelle chaîne de résolution unique `resolve_hc_schedule()` dans `utils.py`, remplaçant la logique dupliquée entre `binary_sensor.py` et `sensors/electricity.py` :

| Ordre | `source` | Origine |
|---|---|---|
| 1 | `contract` | créneaux du taux souscrit |
| 2 | `calendar` | description de la classe temporelle |
| 3 | `linky` | `offPeakLabel`, un seul jeu de plages |
| 4 | `none` | entité indisponible |

La source retenue est exposée en attribut `hc_source` sur le binaire « Heures creuses actives » et sur le capteur « Tarif Tempo en cours ». Un contrat Tempo contraint de se rabattre sur `offPeakLabel` le signale désormais au journal — ce que l'issue #68 demandait explicitement.

**Mapping des taux — issue #37**

`consumptionRates` renvoie `SupplyConsumptionRateType`, un OBJECT à 7 champs sans `temporalClass` ni `possibleTypes` : aucun fragment ne peut l'y atteindre. En revanche `energySupplyRate.rates` renvoie l'interface `SupplyProductRateInterface`, dont le membre `ElectricitySupplyConsumptionRateType` **porte** `temporalClass`. Le gaz retombe sur `SupplyConsumptionRateType` via l'inline fragment.

Conséquence pour #37 : le correctif de l'inversion Hiver HP / Rouge HC, annoncé en 3.2.7, était **inopérant depuis son annulation en 3.3.1**. Le mapping reposait depuis lors uniquement sur le tri par ordre de prix — juste tant que la grille conserve l'ordre `ete_hc < hiver_hc < rouge_hc < ete_hp < hiver_hp < rouge_hp`. Le mapping par code est enfin effectif ; le tri par prix ne sert plus que de secours.

Le test de non-régression `test_mapping_by_temporal_class_code_ignores_price_order` construisait son `temporalClass` sur `consumptionRates` — un chemin que l'API ne produit jamais. Il passait au vert quoi qu'il arrive. Porté sur `rates`, il détecte maintenant la panne.

## Vérification

- 205 tests au vert, `ruff check` et `ruff format --check` propres
- Chaque commit testé à son propre état (194 puis 205)
- Test #37 confirmé sensible : en neutralisant la lecture de `rates`, il passe au rouge — ce que l'ancienne version ne faisait pas

Contre l'API réelle, avec la requête de production et le client de l'intégration :

```
HTTP 200 | erreurs: None
PRM 1918…  offPeakLabel='HC (0H50-6H50;14H50-16H50)'
   source=calendar  ranges=[('00:50','06:50'), ('14:50','16:50')]
PRM 2450…  offPeakLabel='HC (23H30-7H30)'
   source=calendar  ranges=[('23:30','07:30')]
ECO_CONSO_FIXE_3 {'heures_pleines': 0.2173, 'heures_creuses': 0.1596}
```

Les plages obtenues par le calendrier coïncident avec `offPeakLabel` — validation croisée.

## Point ouvert avant merge

Le compte ayant servi aux essais est en HP/HC (`ECO_CONSO_FIXE_3`), pas OctoTempo. La structure des champs est confirmée, mais le contenu réel des descriptions pour les 6 classes `OCTOFLEX_4_V4` demande une confirmation.

@gaby49100, pourrais-tu lancer `python tools/account.py` sur ton contrat et coller la section « Classes temporelles du calendrier » ? Si ces descriptions remontaient vides, la chaîne se rabat sur `offPeakLabel` en le signalant au journal — sans plage inventée, mais #68 resterait alors ouverte.

Fixes #68
Refs #37
