### PR TITLE
fix: parse OctoTempo calendar hour descriptions

### DIFF
--- a/custom_components/octopus_french/utils.py
+++ b/custom_components/octopus_french/utils.py
@@ -47,13 +47,23 @@ def parse_off_peak_hours(off_peak_label: str | None) -> dict[str, Any]:
         if type_match := re.match(r"^([A-Z]+)", off_peak_label):
             result["type"] = type_match.group(1)
 
-        time_pattern = r"(\d+)H(\d+)-(\d+)H(\d+)"
-        matches = re.findall(time_pattern, off_peak_label)
+        # Formats rencontrés :
+        # - offPeakLabel Linky : "HC (22H00-6H00)"
+        # - providerCalendar.description : "Avril à octobre, 21h à 7h et de 11h à 17h"
+        time_pattern = re.compile(
+            r"(\d{1,2})\s*[hH](\d{2})?\s*(?:-|à|a)\s*"
+            r"(\d{1,2})\s*[hH](\d{2})?"
+        )
+        matches = time_pattern.findall(off_peak_label)
 
         total_minutes = 0
 
         for match in matches:
-            start_hour, start_min, end_hour, end_min = map(int, match)
+            start_hour_s, start_min_s, end_hour_s, end_min_s = match
+            start_hour = int(start_hour_s)
+            start_min = int(start_min_s or 0)
+            end_hour = int(end_hour_s)
+            end_min = int(end_min_s or 0)
             start_minutes = start_hour * 60 + start_min
             end_minutes = end_hour * 60 + end_min
 

--- a/tests/test_hc_sensor.py
+++ b/tests/test_hc_sensor.py
@@ -190,12 +190,36 @@ def _make_calendar_data(
 
 # Classes temporelles d'un contrat OctoTempo : une description par couleur.
 _OCTOTEMPO_CLASSES = [
-    {"code": "HPE", "label": "HP Été", "description": ""},
-    {"code": "HCE", "label": "HC Été", "description": "21H00-7H00;11H00-17H00"},
-    {"code": "HPHI", "label": "HP Hiver", "description": ""},
-    {"code": "HCHI", "label": "HC Hiver", "description": "21H00-7H00"},
-    {"code": "HPP", "label": "HP Rouge", "description": ""},
-    {"code": "HCP", "label": "HC Rouge", "description": "2H00-6H00"},
+    {
+        "code": "HPE",
+        "label": "HP Été",
+        "description": "Avril à octobre, de 7h à 11h et de 17h à 21h",
+    },
+    {
+        "code": "HCE",
+        "label": "HC Été",
+        "description": "Avril à octobre, 21h à 7h et de 11h à 17h",
+    },
+    {
+        "code": "HPHI",
+        "label": "HP Hiver",
+        "description": "Novembre à mars, de 7h à 21h",
+    },
+    {
+        "code": "HCHI",
+        "label": "HC Hiver",
+        "description": "Novembre à mars, de 21h à 7h",
+    },
+    {
+        "code": "HPP",
+        "label": "HP Rouge",
+        "description": "Heures pleines en jour rouge, de 7h à 21h",
+    },
+    {
+        "code": "HCP",
+        "label": "HC Rouge",
+        "description": "Heures creuses en jour rouge, de 21h à 7h",
+    },
 ]
 
 
@@ -239,7 +263,7 @@ class TestFindCalendarHcRanges:
 
         rouge = find_calendar_hc_ranges(data, "PRM1", tempo_color="ROUGE")
         assert rouge is not None
-        assert [(r["start"], r["end"]) for r in rouge["ranges"]] == [("02:00", "06:00")]
+        assert [(r["start"], r["end"]) for r in rouge["ranges"]] == [("21:00", "07:00")]
 
     def test_empty_description_returns_none(self):
         """Une description vide ne produit aucune plage inventée."""


### PR DESCRIPTION
## Summary

- Update `parse_off_peak_hours` to understand the real Octopus `providerCalendar.temporalClasses[].description` text format, e.g. `21h à 7h` and `11h à 17h`.
- Keep support for the existing Linky-style `22H00-6H00` labels.
- Update the OctoTempo regression test data to use the actual descriptions returned by the Octopus API for summer/winter/red periods.

## Context

A previous PR fixed the data path so OctoTempo schedules are read from the Octopus API calendar instead of being guessed. However, after updating the integration through HACS, the HC/HP binary sensor was still wrong on a real OctoTempo Home Assistant installation.

The root cause was that the calendar path was reached, but the description parser only supported labels like:

```text
21H00-7H00;11H00-17H00
```

The Octopus API currently returns descriptions like:

```text
Avril à octobre, 21h à 7h et de 11h à 17h
Novembre à mars, de 21h à 7h
Heures creuses en jour rouge, de 21h à 7h
```

Because these descriptions were not parsed, the integration fell back to the Linky `offPeakLabel` schedule (`22:00 - 06:00`), which does not match the OctoTempo contract.

## Real HA validation

This patch was tested manually by replacing `custom_components/octopus_french/utils.py` directly in a real Home Assistant instance running the HACS-installed integration.

Before the patch, the OctoTempo HC sensor used the fallback Linky schedule:

```text
hc_source: linky
hc_range_1: 22:00 - 06:00
```

After replacing the file and restarting Home Assistant, the same installation now reports the calendar-derived OctoTempo summer schedule:

```text
state: on
hc_source: calendar
hc_range_1: 21:00 - 07:00
hc_range_2: 11:00 - 17:00
```

The PR is opened as draft while the user monitors the real HA installation for a full day to confirm the HC/HP transitions switch correctly across all expected boundaries.

Private identifiers from the HA instance are intentionally omitted/masked.

## Test plan

- [x] `python -m pytest tests/test_hc_sensor.py -q`
- [x] `python -m pytest -q`
- [x] `python -m ruff check .`
